### PR TITLE
VALUES was incorrectly treated as a function

### DIFF
--- a/sqlparse/lexer.py
+++ b/sqlparse/lexer.py
@@ -179,6 +179,7 @@ class Lexer(object):
             (r'\$([a-zA-Z_][a-zA-Z0-9_]*)?\$', tokens.Name.Builtin),
             (r'\?{1}', tokens.Name.Placeholder),
             (r'[$:?%][a-zA-Z0-9_]+', tokens.Name.Placeholder),
+            (r'VALUES', tokens.Keyword),
             (r'@[a-zA-Z_][a-zA-Z0-9_]+', tokens.Name),
             (r'[a-zA-Z_][a-zA-Z0-9_]*(?=[.(])', tokens.Name),  # see issue39
             (r'[-]?0x[0-9a-fA-F]+', tokens.Number.Hexadecimal),

--- a/tests/test_grouping.py
+++ b/tests/test_grouping.py
@@ -53,6 +53,12 @@ class TestGrouping(TestCaseBase):
         self.ndiffAssertEqual(s, unicode(parsed))
         self.assert_(isinstance(parsed.tokens[-1].tokens[3], sql.Identifier))
 
+        s = "INSERT INTO `test` VALUES('foo', 'bar');"
+        parsed = sqlparse.parse(s)[0]
+        types = [l.ttype for l in parsed.tokens if not l.is_whitespace()]
+        self.assertEquals(types, [T.DML, T.Keyword, None,
+                                  T.Keyword, None, T.Punctuation])
+
     def test_identifier_wildcard(self):
         p = sqlparse.parse('a.*, b.id')[0]
         self.assert_(isinstance(p.tokens[0], sql.IdentifierList))


### PR DESCRIPTION
In the version of sqlparse in debian, (INSERT...) VALUES was treated as a function. Then I broke it somehow with my changes to the lexer so it was grouped with table name: <Identifier 'test V...' at 0xb732982c>.

This fix is probably not ideal to solve the issue, but I wanted to submit a fix of some sort as I broke it.
