### PR TITLE
Stop VARCHAR being lost by grouping logic.

### DIFF
--- a/sqlparse/engine/grouping.py
+++ b/sqlparse/engine/grouping.py
@@ -289,10 +289,11 @@ def group_aliased(tlist):
     while token:
         next_ = tlist.token_next(tlist.token_index(token))
         if next_ is not None and isinstance(next_, clss):
-            grp = tlist.tokens_between(token, next_)[1:]
-            token.tokens.extend(grp)
-            for t in grp:
-                tlist.tokens.remove(t)
+            if not next_.value.upper().startswith('VARCHAR'):
+                grp = tlist.tokens_between(token, next_)[1:]
+                token.tokens.extend(grp)
+                for t in grp:
+                    tlist.tokens.remove(t)
         idx = tlist.token_index(token) + 1
         token = tlist.token_next_by_instance(idx, clss)
 

--- a/tests/test_grouping.py
+++ b/tests/test_grouping.py
@@ -189,6 +189,10 @@ class TestGrouping(TestCaseBase):
         self.assert_(isinstance(p.tokens[0], sql.Function))
         self.assertEqual(len(list(p.tokens[0].get_parameters())), 2)
 
+    def test_varchar(self):
+        p = sqlparse.parse('"text" Varchar(50) NOT NULL')[0]
+        self.assert_(isinstance(p.tokens[2], sql.Function))
+        
 
 class TestStatement(TestCaseBase):
 


### PR DESCRIPTION
Added special case grouping logic for VARCHAR, otherwise it gets lost from field definitions. Includes test.
Note, this probably wants a bit of rework to make it fit nicely with the token processing. I just started looking at this sqlparse, so I don't know my way around enough to do that. In particular, probably want to test that the current token is an identifier.

Cheers ;)
