### PR TITLE
Unicode-escape for binary data (sqlparse/lexer.py)

### DIFF
--- a/sqlparse/lexer.py
+++ b/sqlparse/lexer.py
@@ -233,7 +233,10 @@ class Lexer(object):
             except UnicodeDecodeError:
                 text = text.decode('latin1')
         else:
-            text = text.decode(self.encoding)
+            try:
+                text = text.decode(self.encoding)
+            except UnicodeDecodeError:
+                text = text.decode('unicode-escape')
 
         if self.tabsize > 0:
             text = text.expandtabs(self.tabsize)


### PR DESCRIPTION
fix "UnicodeDecodeError: 'utf8' codec can't decode byte 0xfd in position 71: invalid start byte" when query contains binary data
