### PR TITLE
Stop parsing tables at first keyword after "from".

### DIFF
--- a/examples/extract_table_names.py
+++ b/examples/extract_table_names.py
@@ -24,7 +24,9 @@ def is_subselect(parsed):
 def extract_from_part(parsed):
     from_seen = False
     for item in parsed.tokens:
-        if from_seen:
+        if item.ttype is Keyword:
+			from_seen = False
+		elif from_seen:
             if is_subselect(item):
                 for x in extract_from_part(item):
                     yield x


### PR DESCRIPTION
Currently, the parser isn't smart enough to acknowledge the end of the from-clause list so keywords as table names will still fail. But in simple tests, this solution works.
Best-practice: don't use SQL keywords as table names. :)
