### PR TITLE
Parenthesis, Functions and Arithmetic Expressions in Identifiers

### DIFF
--- a/sqlparse/engine/grouping.py
+++ b/sqlparse/engine/grouping.py
@@ -148,7 +148,9 @@ def group_identifier(tlist):
                                    T.String.Single,
                                    T.Name,
                                    T.Wildcard,
-                                   T.Literal.Number.Integer))))
+                                   T.Literal.Number.Integer,
+                                   T.Literal.Number.Float)
+                       or isinstance(y, (sql.Parenthesis, sql.Function)))))
         for t in tl.tokens[i:]:
             # Don't take whitespaces into account.
             if t.ttype is T.Whitespace:
@@ -163,8 +165,9 @@ def group_identifier(tlist):
         # chooses the next token. if two tokens are found then the
         # first is returned.
         t1 = tl.token_next_by_type(
-            i, (T.String.Symbol, T.String.Single, T.Name))
-        t2 = tl.token_next_by_instance(i, sql.Function)
+            i, (T.String.Symbol, T.String.Single, T.Name, T.Literal.Number.Integer,
+                T.Literal.Number.Float))
+        t2 = tl.token_next_by_instance(i, (sql.Function, sql.Parenthesis))
         if t1 and t2:
             i1 = tl.token_index(t1)
             i2 = tl.token_index(t2)
@@ -192,7 +195,9 @@ def group_identifier(tlist):
         if identifier_tokens and identifier_tokens[-1].ttype is T.Whitespace:
             identifier_tokens = identifier_tokens[:-1]
         if not (len(identifier_tokens) == 1
-                and isinstance(identifier_tokens[0], sql.Function)):
+                and (isinstance(identifier_tokens[0], (sql.Function, sql.Parenthesis))
+                     or identifier_tokens[0].ttype in (T.Literal.Number.Integer,
+                                                       T.Literal.Number.Float))):
             group = tlist.group_tokens(sql.Identifier, identifier_tokens)
             idx = tlist.token_index(group) + 1
         else:

--- a/tests/test_grouping.py
+++ b/tests/test_grouping.py
@@ -59,6 +59,15 @@ class TestGrouping(TestCaseBase):
         self.assertEquals(types, [T.DML, T.Keyword, None,
                                   T.Keyword, None, T.Punctuation])
 
+        s = "select 1.0*(a+b) as col, sum(c)/sum(d) from myschema.mytable"
+        parsed = sqlparse.parse(s)[0]
+        self.assertEqual(len(parsed.tokens), 7)
+        self.assert_(isinstance(parsed.tokens[2], sql.IdentifierList))
+        self.assertEqual(len(parsed.tokens[2].tokens), 4)
+        identifiers = list(parsed.tokens[2].get_identifiers())
+        self.assertEqual(len(identifiers), 2)
+        self.assertEquals(identifiers[0].get_alias(), u"col")
+
     def test_identifier_wildcard(self):
         p = sqlparse.parse('a.*, b.id')[0]
         self.assert_(isinstance(p.tokens[0], sql.IdentifierList))


### PR DESCRIPTION
Parenthesis, functions and arithmetic expressions in column definitions can be grouped into the identifier.
Resolves the issues -
https://github.com/andialbrecht/sqlparse/issues/109
https://github.com/andialbrecht/sqlparse/issues/106
And resolved many issues I was running into parsing user generated queries using this awesome module.
