### PR TITLE
Fix Function.get_parameters() with 1 literal as its parameter

### DIFF
--- a/sqlparse/sql.py
+++ b/sqlparse/sql.py
@@ -628,6 +628,8 @@ class Function(TokenList):
                 return t.get_identifiers()
             elif isinstance(t, Identifier):
                 return [t,]
+            elif t.ttype in T.Literal:
+                return [t,]
         return []
 
 

--- a/tests/test_parse.py
+++ b/tests/test_parse.py
@@ -116,6 +116,11 @@ class SQLParseTest(TestCaseBase):
         self.assertEqual(len(t), 1)
         self.assert_(isinstance(t[0], sqlparse.sql.Identifier))
 
+    def test_function_param_single_literal(self):
+        t = sqlparse.parse('foo(5)')[0].tokens[0].get_parameters()
+        self.assertEqual(len(t), 1)
+        self.assert_(t[0].ttype is T.Number.Integer)
+
 
 def test_quoted_identifier():
     t = sqlparse.parse('select x.y as "z" from foo')[0].tokens


### PR DESCRIPTION
Greetings,

I started using sqlparse with a project of mine and noticed that calling get_parameters() on Function tokens with single Literals as parameters returns an empty list (i.e. "SELECT foo('somestring')" --> []).  After some headdesking, I saw that get_parameters takes into account single Identifier tokens but not Literal ones, so I added cheapo support for it and uhh voila.  Attached is a (rather shoddy) fix and the test case associated with it.  Let me know if this is too hacky.

Thanks a ton
