### PR TITLE
Fix Function.get_parameters() returning empty list for SQL functions tha...

### DIFF
--- a/sqlparse/sql.py
+++ b/sqlparse/sql.py
@@ -626,9 +626,9 @@ class Function(TokenList):
         for t in parenthesis.tokens:
             if isinstance(t, IdentifierList):
                 return t.get_identifiers()
-            elif isinstance(t, Identifier):
-                return [t,]
-            elif t.ttype in T.Literal:
+            elif isinstance(t, Identifier) or \
+                isinstance(t, Function) or \
+                t.ttype in T.Literal:
                 return [t,]
         return []
 

--- a/tests/test_parse.py
+++ b/tests/test_parse.py
@@ -121,6 +121,11 @@ class SQLParseTest(TestCaseBase):
         self.assertEqual(len(t), 1)
         self.assert_(t[0].ttype is T.Number.Integer)
 
+    def test_nested_function(self):
+        t = sqlparse.parse('foo(bar(5))')[0].tokens[0].get_parameters()
+        self.assertEqual(len(t), 1)
+        self.assert_(type(t[0]) is sqlparse.sql.Function)
+
 
 def test_quoted_identifier():
     t = sqlparse.parse('select x.y as "z" from foo')[0].tokens


### PR DESCRIPTION
...t have a single nested function as a param

Another one for you, almost the same fix as the one for Literal tokens, only for single nested Functions (i.e. "SELECT FOO(NOW())")
