### PR TITLE
Handle modulo operator without spaces

### DIFF
--- a/sqlparse/lexer.py
+++ b/sqlparse/lexer.py
@@ -180,7 +180,8 @@ class Lexer(object):
             (r'\$([^\W\d]\w*)?\$', tokens.Name.Builtin),
             (r'\?{1}', tokens.Name.Placeholder),
             (r'%\(\w+\)s', tokens.Name.Placeholder),
-            (r'[$:?%]\w+', tokens.Name.Placeholder),
+            (r'%s', tokens.Name.Placeholder),
+            (r'[$:?]\w+', tokens.Name.Placeholder),
             # FIXME(andi): VALUES shouldn't be listed here
             # see https://github.com/andialbrecht/sqlparse/pull/64
             (r'VALUES', tokens.Keyword),

--- a/tests/test_parse.py
+++ b/tests/test_parse.py
@@ -99,6 +99,10 @@ class SQLParseTest(TestCaseBase):
         self.assert_(t[-1].ttype is sqlparse.tokens.Name.Placeholder)
         self.assertEqual(t[-1].value, '$a')
 
+    def test_modulo_not_placeholder(self):
+        tokens = list(sqlparse.lexer.tokenize('x %3'))
+        self.assertEqual(tokens[2][0], sqlparse.tokens.Operator)
+
     def test_access_symbol(self):  # see issue27
         t = sqlparse.parse('select a.[foo bar] as foo')[0].tokens
         self.assert_(isinstance(t[-1], sqlparse.sql.Identifier))


### PR DESCRIPTION
`x %3` should be interpreted as a modulo operation, not a parameter marker.

Co-authored-by: Rocky Meza rmeza@fusionbox.com
