### PR TITLE
Recognize escaped backslashes within strings

### DIFF
--- a/sqlparse/lexer.py
+++ b/sqlparse/lexer.py
@@ -191,8 +191,7 @@ class Lexer(object):
             (r'[-]?[0-9]*(\.[0-9]+)?[eE][-]?[0-9]+', tokens.Number.Float),
             (r'[-]?[0-9]*\.[0-9]+', tokens.Number.Float),
             (r'[-]?[0-9]+', tokens.Number.Integer),
-            # TODO: Backslash escapes?
-            (r"'(''|\\'|[^'])*'", tokens.String.Single),
+            (r"'(''|\\\\|\\'|[^'])*'", tokens.String.Single),
             # not a real string literal in ANSI SQL:
             (r'(""|".*?[^\\]")', tokens.String.Symbol),
             (r'(?<=[\w\]])(\[[^\]]*?\])', tokens.Punctuation.ArrayIndex),

--- a/tests/test_split.py
+++ b/tests/test_split.py
@@ -22,6 +22,10 @@ class SQLSplitTest(TestCaseBase):
         self.ndiffAssertEqual(unicode(stmts[0]), self._sql1)
         self.ndiffAssertEqual(unicode(stmts[1]), sql2)
 
+    def test_split_backslash(self):
+        stmts = sqlparse.parse(r"select '\\'; select '\''; select '\\\'';")
+        self.assertEqual(len(stmts), 3)
+
     def test_create_function(self):
         sql = load_file('function.sql')
         stmts = sqlparse.parse(sql)


### PR DESCRIPTION
Previously if a single quoted string ended with an escaped backslash,
parsing would not consider the string to be terminated.