### PR TITLE
Add high-level function to parse column names and types in CREATE TABLE statements

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -4,6 +4,8 @@ Development version
 Bug Fixes
 * Fix a regression in get_alias() introduced in 0.1.15 (issue185).
 
+Enhancements
+* Add high-level function to parse column names and types in CREATE TABLE statements
 
 Release 0.1.15 (Apr 15, 2015)
 -----------------------------

--- a/sqlparse/filters.py
+++ b/sqlparse/filters.py
@@ -596,7 +596,7 @@ class InfoCreateTable(object):
                             state = St.finished
                         else:
                             parens -= 1
-                    elif value == ',':
+                    elif value == ',' and parens == 0:
                         state = St.column_name
             elif state == St.column_ignore_rest:
                 if token_type in Punctuation and parens == 0: # ignore anything in parens

--- a/sqlparse/filters.py
+++ b/sqlparse/filters.py
@@ -515,6 +515,7 @@ class InfoCreateTable(object):
     # sqlparse outputs some tokens as Keyword type at places where they are names
     ALLOWED_KEYWORD_AS_NAME = set((
         'data',
+        'source',
         'type',
     ))
 

--- a/sqlparse/filters.py
+++ b/sqlparse/filters.py
@@ -576,7 +576,7 @@ class InfoCreateTable(object):
                     error = 'No opening paren for CREATE TABLE'
             elif state == St.column_name:
                 if token_type in Name or (token_type in Keyword and value.lower() in InfoCreateTable.ALLOWED_KEYWORD_AS_NAME):
-                    column = [self._to_column_name(value), None]
+                    column = [self._to_column_name(value), None, None]
                     state = St.column_type
                 elif token_type in Keyword:
                     state = St.ignore_rest
@@ -625,6 +625,10 @@ class InfoCreateTable(object):
                             columns[len(columns)] = tuple(column)
 
                         column = None
+                elif token_type in Keyword and parens == 0:
+                    keyword_value = value.upper()
+                    if keyword_value in ('NULL', 'NOT NULL'):
+                        column[2] = keyword_value
                 elif token_type in Punctuation and parens > 0:
                     # ignore anything in parens
                     if value == '(':

--- a/sqlparse/functions.py
+++ b/sqlparse/functions.py
@@ -6,7 +6,7 @@ Created on 17/05/2012
 Several utility functions to extract info from the SQL sentences
 '''
 
-from sqlparse.filters import ColumnsSelect, Limit
+from sqlparse.filters import ColumnsSelect, InfoCreateTable, Limit
 from sqlparse.pipeline import Pipeline
 from sqlparse.tokens import Keyword, Whitespace
 
@@ -31,6 +31,17 @@ def getcolumns(stream):
     pipe.append(ColumnsSelect())
 
     return pipe(stream)
+
+
+
+def get_create_table_info(stream):
+    """Function that return the colums of a CREATE TABLE statement including their type"""
+    pipe = Pipeline()
+
+    pipe.append(InfoCreateTable())
+
+    return pipe(stream)
+
 
 
 class IsType(object):

--- a/sqlparse/functions.py
+++ b/sqlparse/functions.py
@@ -39,6 +39,10 @@ def get_create_table_info(stream):
     declaration.
 
     The nullable declaration is None if not specified, else 'NOT NULL' or 'NULL'.
+
+    >>> import lexer
+    >>> get_create_table_info(lexer.tokenize('CREATE TABLE t ( a INT NOT NULL )'))
+    [('t', {0: ('a', 'INT', 'NOT NULL')})]
     """
     pipe = Pipeline()
 
@@ -57,3 +61,7 @@ class IsType(object):
         for token_type, value in stream:
             if token_type not in Whitespace:
                 return token_type in Keyword and value == self.type
+
+if __name__ == '__main__':
+    import doctest
+    doctest.testmod()

--- a/sqlparse/functions.py
+++ b/sqlparse/functions.py
@@ -12,7 +12,6 @@ from sqlparse.tokens import Keyword, Whitespace
 
 
 def getlimit(stream):
-    """Function that return the LIMIT of a input SQL """
     pipe = Pipeline()
 
     pipe.append(Limit())
@@ -35,7 +34,12 @@ def getcolumns(stream):
 
 
 def get_create_table_info(stream):
-    """Function that return the colums of a CREATE TABLE statement including their type"""
+    """
+    Function that returns the columns of a CREATE TABLE statement including their type and NULL
+    declaration.
+
+    The nullable declaration is None if not specified, else 'NOT NULL' or 'NULL'.
+    """
     pipe = Pipeline()
 
     pipe.append(InfoCreateTable())

--- a/tests/test_doctests.py
+++ b/tests/test_doctests.py
@@ -1,0 +1,5 @@
+import doctest
+
+from sqlparse import functions
+
+doctest.testmod(functions)

--- a/tests/test_functions.py
+++ b/tests/test_functions.py
@@ -185,7 +185,9 @@ class Test_GetCreateTableInfo(TestCase, TestCasePy27Features):
 
     sql3 = """
         CREATE TABLE a ( afield INT PRIMARY KEY NOT NULL );
-        CREATE TABLE b ( bfield INT PRIMARY KEY NOT NULL );
+        CREATE TABLE b ( bfield VARCHAR(10) PRIMARY KEY NOT NULL ) ;
+        CREATE TABLE c ( cfield TEXT PRIMARY KEY NOT NULL ) this gets ignored;
+        CREATE TABLE d ( dfield NVARCHAR PRIMARY KEY NOT NULL )
     """
 
     sql4 = """
@@ -218,14 +220,14 @@ class Test_GetCreateTableInfo(TestCase, TestCasePy27Features):
     def test_get_create_table_info1(self):
         info = get_create_table_info(tokenize(self.sql1))
 
-        self.assertEqual(info, ('item', {
+        self.assertEqual(info, [('item', {
             0: ('id',         'INT'),
             1: ('type',       'VARCHAR'),
             2: ('score',      'DOUBLE'),
             3: ('url',        'TEXT'),
             4: ('text',       'TEXT'),
             5: ('item2other', 'INT'),
-        }))
+        })])
 
     def test_get_create_table_info2(self):
         with self.assertRaisesRegexp(ValueError, 'Not a CREATE TABLE statement'):
@@ -234,23 +236,33 @@ class Test_GetCreateTableInfo(TestCase, TestCasePy27Features):
     def test_get_create_table_info3(self):
         info = get_create_table_info(tokenize(self.sql3))
 
-        # TODO: multiple statements in stream not handled
-        self.assertEqual(info, ('a', {
-            0: ('afield', 'INT'),
-        }))
+        self.assertEqual(info, [
+            ('a', {
+                0: ('afield', 'INT'),
+            }),
+            ('b', {
+                0: ('bfield', 'VARCHAR'),
+            }),
+            ('c', {
+                0: ('cfield', 'TEXT'),
+            }),
+            ('d', {
+                0: ('dfield', 'NVARCHAR'),
+            }),
+        ])
 
     def test_get_create_table_info4(self):
         info = get_create_table_info(tokenize(self.sql4))
 
-        self.assertEqual(info, ('example', {
+        self.assertEqual(info, [('example', {
             0: ('id', 'INT'),
             1: ('data', 'VARCHAR'),
-        }))
+        })])
 
     def test_get_create_table_info5(self):
         info = get_create_table_info(tokenize(self.sql5))
 
-        self.assertEqual(info, ('mydb.mytable', {
+        self.assertEqual(info, [('mydb.mytable', {
              0: ('a', 'INT'),
              1: ('b', 'DECIMAL'),
              2: ('c', 'DATE'),
@@ -265,7 +277,7 @@ class Test_GetCreateTableInfo(TestCase, TestCasePy27Features):
             11: ('l', 'VARCHAR'),
             12: ('m', 'DECIMAL'),
             13: ('n', 'VARCHAR'),
-        }))
+        })])
 
 
 class Test_GetLimit(Test_SQL):

--- a/tests/test_functions.py
+++ b/tests/test_functions.py
@@ -233,6 +233,7 @@ class Test_GetCreateTableInfo(TestCase, TestCasePy27Features):
 
     sql12 = 'CREATE TABLE a,'
     sql13 = 'CREATE TABLE t (a INT, a INT)'
+    sql14 = 'CREATE TABLE pair ( id VARCHAR(10) PRIMARY KEY NOT NULL, source VARCHAR(3) NOT NULL, target VARCHAR(3) NOT NULL );'
 
     def test_get_create_table_info1(self):
         info = get_create_table_info(tokenize(self.sql1))
@@ -297,6 +298,15 @@ class Test_GetCreateTableInfo(TestCase, TestCasePy27Features):
 
         self.assertEqual(info, [('t', {
             0: ('a', 'INT', None),
+        })])
+
+    def test_get_create_table_info14(self):
+        info = get_create_table_info(tokenize(self.sql14))
+
+        self.assertEqual(info, [('pair', {
+            0: ('id', 'VARCHAR', 'NOT NULL'),
+            1: ('source', 'VARCHAR', 'NOT NULL'),
+            2: ('target', 'VARCHAR', 'NOT NULL'),
         })])
 
     def test_get_create_table_info_errors(self):

--- a/tests/test_functions.py
+++ b/tests/test_functions.py
@@ -170,7 +170,7 @@ class Test_GetCreateTableInfo(TestCase, TestCasePy27Features):
         CREATE TABLE item (
             id INT PRIMARY KEY NOT NULL,
             type VARCHAR(3) NOT NULL,
-            score DOUBLE NULL,
+            score DOUBLE,
             url TEXT NULL,
             text TEXT NOT NULL,
             item2other INT NULL,
@@ -185,9 +185,9 @@ class Test_GetCreateTableInfo(TestCase, TestCasePy27Features):
 
     sql3 = """
         CREATE TABLE a ( afield INT PRIMARY KEY NOT NULL );
-        CREATE TABLE b ( bfield VARCHAR(10) PRIMARY KEY NOT NULL ) ;
+        CREATE TABLE b ( bfield VARCHAR(10) NULL ) ;
         CREATE TABLE c ( cfield TEXT PRIMARY KEY NOT NULL ) this gets ignored;
-        CREATE TABLE d ( dfield NVARCHAR PRIMARY KEY NOT NULL )
+        CREATE TABLE d ( dfield NVARCHAR PRIMARY KEY )
     """
 
     sql4 = """
@@ -207,7 +207,7 @@ class Test_GetCreateTableInfo(TestCase, TestCasePy27Features):
             `f` VARCHAR(1) not null ,
             `g` VARCHAR(1) not null,
             `h` DECIMAL(13,2)unsigned not null ,
-            `i` DECIMAL(4,0)unsigned not null ,
+            `i` DECIMAL(4,0)unsigned ,
             `j` VARCHAR(30)unsigned not null,
             `k` DECIMAL(13,2) unsigned not null,
             `l` VARCHAR(1)not null ,
@@ -221,12 +221,12 @@ class Test_GetCreateTableInfo(TestCase, TestCasePy27Features):
         info = get_create_table_info(tokenize(self.sql1))
 
         self.assertEqual(info, [('item', {
-            0: ('id',         'INT'),
-            1: ('type',       'VARCHAR'),
-            2: ('score',      'DOUBLE'),
-            3: ('url',        'TEXT'),
-            4: ('text',       'TEXT'),
-            5: ('item2other', 'INT'),
+            0: ('id',         'INT',     'NOT NULL'),
+            1: ('type',       'VARCHAR', 'NOT NULL'),
+            2: ('score',      'DOUBLE',  None),
+            3: ('url',        'TEXT',    'NULL'),
+            4: ('text',       'TEXT',    'NOT NULL'),
+            5: ('item2other', 'INT',     'NULL'),
         })])
 
     def test_get_create_table_info2(self):
@@ -238,16 +238,16 @@ class Test_GetCreateTableInfo(TestCase, TestCasePy27Features):
 
         self.assertEqual(info, [
             ('a', {
-                0: ('afield', 'INT'),
+                0: ('afield', 'INT', 'NOT NULL'),
             }),
             ('b', {
-                0: ('bfield', 'VARCHAR'),
+                0: ('bfield', 'VARCHAR', 'NULL'),
             }),
             ('c', {
-                0: ('cfield', 'TEXT'),
+                0: ('cfield', 'TEXT', 'NOT NULL'),
             }),
             ('d', {
-                0: ('dfield', 'NVARCHAR'),
+                0: ('dfield', 'NVARCHAR', None),
             }),
         ])
 
@@ -255,28 +255,28 @@ class Test_GetCreateTableInfo(TestCase, TestCasePy27Features):
         info = get_create_table_info(tokenize(self.sql4))
 
         self.assertEqual(info, [('example', {
-            0: ('id', 'INT'),
-            1: ('data', 'VARCHAR'),
+            0: ('id', 'INT', None),
+            1: ('data', 'VARCHAR', None),
         })])
 
     def test_get_create_table_info5(self):
         info = get_create_table_info(tokenize(self.sql5))
 
         self.assertEqual(info, [('mydb.mytable', {
-             0: ('a', 'INT'),
-             1: ('b', 'DECIMAL'),
-             2: ('c', 'DATE'),
-             3: ('d', 'DECIMAL'),
-             4: ('e', 'VARCHAR'),
-             5: ('f', 'VARCHAR'),
-             6: ('g', 'VARCHAR'),
-             7: ('h', 'DECIMAL'),
-             8: ('i', 'DECIMAL'),
-             9: ('j', 'VARCHAR'),
-            10: ('k', 'DECIMAL'),
-            11: ('l', 'VARCHAR'),
-            12: ('m', 'DECIMAL'),
-            13: ('n', 'VARCHAR'),
+             0: ('a', 'INT',     'NOT NULL'),
+             1: ('b', 'DECIMAL', 'NOT NULL'),
+             2: ('c', 'DATE',    None),
+             3: ('d', 'DECIMAL', 'NOT NULL'),
+             4: ('e', 'VARCHAR', 'NOT NULL'),
+             5: ('f', 'VARCHAR', 'NOT NULL'),
+             6: ('g', 'VARCHAR', 'NOT NULL'),
+             7: ('h', 'DECIMAL', 'NOT NULL'),
+             8: ('i', 'DECIMAL', None),
+             9: ('j', 'VARCHAR', 'NOT NULL'),
+            10: ('k', 'DECIMAL', 'NOT NULL'),
+            11: ('l', 'VARCHAR', 'NOT NULL'),
+            12: ('m', 'DECIMAL', 'NOT NULL'),
+            13: ('n', 'VARCHAR', 'NOT NULL'),
         })])
 
 

--- a/tests/test_functions.py
+++ b/tests/test_functions.py
@@ -8,11 +8,40 @@ from unittest import main, TestCase
 from sqlparse.filters import IncludeStatement, Tokens2Unicode
 from sqlparse.lexer import tokenize
 
+import re
 import sys
 sys.path.insert(0, '..')
 
 from sqlparse.filters import compact
-from sqlparse.functions import getcolumns, getlimit, IsType
+from sqlparse.functions import getcolumns, get_create_table_info, getlimit, IsType
+
+
+class TestCasePy27Features(object):
+    class __AssertRaisesContext(object):
+        def __init__(self, expected_exception, expected_regexp):
+            self.expected = expected_exception
+            self.expected_regexp = expected_regexp
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, exc_type, exc_value, tb):
+            if exc_type is None:
+                raise self.failureException('%s not raised' % exc_type.__name__)
+            if not issubclass(exc_type, self.expected):
+                return False
+            self.exception = exc_value
+            expected_regexp = self.expected_regexp
+            if isinstance(expected_regexp, basestring):
+                expected_regexp = re.compile(expected_regexp)
+            if not expected_regexp.search(str(exc_value)):
+                raise self.failureException('"%s" does not match "%s"' %
+                                            (expected_regexp.pattern, str(exc_value)))
+            return True
+
+    """Adds simple replacements for unittest features not available before Python 2.7"""
+    def assertRaisesRegexp(self, expected_exception, expected_regexp):
+        return self.__AssertRaisesContext(expected_exception, expected_regexp)
 
 
 class Test_IncludeStatement(TestCase):
@@ -134,6 +163,109 @@ class Test_GetColumns(Test_SQL):
         self.assertEqual(columns, ['st_dev', 'st_uid', 'st_gid', 'st_mode',
                                    'st_ino', 'st_nlink', 'st_ctime',
                                    'st_atime', 'st_mtime', 'st_size', 'size'])
+
+
+class Test_GetCreateTableInfo(TestCase, TestCasePy27Features):
+    sql1 = """
+        CREATE TABLE item (
+            id INT PRIMARY KEY NOT NULL,
+            type VARCHAR(3) NOT NULL,
+            score DOUBLE NULL,
+            url TEXT NULL,
+            text TEXT NOT NULL,
+            item2other INT NULL,
+
+            FOREIGN KEY(item2other) REFERENCES othertable(id)
+        );
+    """
+
+    sql2 = """
+        CREATE UNIQUE INDEX t1b ON t1(b);
+    """
+
+    sql3 = """
+        CREATE TABLE a ( afield INT PRIMARY KEY NOT NULL );
+        CREATE TABLE b ( bfield INT PRIMARY KEY NOT NULL );
+    """
+
+    sql4 = """
+        CREATE TABLE example (
+            id INT,
+            data VARCHAR(10)
+        ) TYPE=innodb;
+    """
+
+    sql5 = """
+        CREATE TABLE mydb.mytable (
+            `a` INT(10) unsigned not null default '0',
+            `b` DECIMAL(6,0) unsigned NOT null ,
+            `c` DATE,
+            `d` DECIMAL(4,0) unsigned not null ,
+            `e` VARCHAR(6) not null ,
+            `f` VARCHAR(1) not null ,
+            `g` VARCHAR(1) not null,
+            `h` DECIMAL(13,2)unsigned not null ,
+            `i` DECIMAL(4,0)unsigned not null ,
+            `j` VARCHAR(30)unsigned not null,
+            `k` DECIMAL(13,2) unsigned not null,
+            `l` VARCHAR(1)not null ,
+            `m` DECIMAL(13,2) unsigned not null,
+            `n` VARCHAR(1) unsigned not null,
+            PRIMARY KEY (`a`)
+        )ENGINE=InnoDB;
+    """
+
+    def test_get_create_table_info1(self):
+        info = get_create_table_info(tokenize(self.sql1))
+
+        self.assertEqual(info, ('item', {
+            0: ('id',         'INT'),
+            1: ('type',       'VARCHAR'),
+            2: ('score',      'DOUBLE'),
+            3: ('url',        'TEXT'),
+            4: ('text',       'TEXT'),
+            5: ('item2other', 'INT'),
+        }))
+
+    def test_get_create_table_info2(self):
+        with self.assertRaisesRegexp(ValueError, 'Not a CREATE TABLE statement'):
+            info = get_create_table_info(tokenize(self.sql2))
+
+    def test_get_create_table_info3(self):
+        info = get_create_table_info(tokenize(self.sql3))
+
+        # TODO: multiple statements in stream not handled
+        self.assertEqual(info, ('a', {
+            0: ('afield', 'INT'),
+        }))
+
+    def test_get_create_table_info4(self):
+        info = get_create_table_info(tokenize(self.sql4))
+
+        self.assertEqual(info, ('example', {
+            0: ('id', 'INT'),
+            1: ('data', 'VARCHAR'),
+        }))
+
+    def test_get_create_table_info5(self):
+        info = get_create_table_info(tokenize(self.sql5))
+
+        self.assertEqual(info, ('mydb.mytable', {
+             0: ('a', 'INT'),
+             1: ('b', 'DECIMAL'),
+             2: ('c', 'DATE'),
+             3: ('d', 'DECIMAL'),
+             4: ('e', 'VARCHAR'),
+             5: ('f', 'VARCHAR'),
+             6: ('g', 'VARCHAR'),
+             7: ('h', 'DECIMAL'),
+             8: ('i', 'DECIMAL'),
+             9: ('j', 'VARCHAR'),
+            10: ('k', 'DECIMAL'),
+            11: ('l', 'VARCHAR'),
+            12: ('m', 'DECIMAL'),
+            13: ('n', 'VARCHAR'),
+        }))
 
 
 class Test_GetLimit(Test_SQL):

--- a/tests/test_functions.py
+++ b/tests/test_functions.py
@@ -234,6 +234,15 @@ class Test_GetCreateTableInfo(TestCase, TestCasePy27Features):
     sql12 = 'CREATE TABLE a,'
     sql13 = 'CREATE TABLE t (a INT, a INT)'
     sql14 = 'CREATE TABLE pair ( id VARCHAR(10) PRIMARY KEY NOT NULL, source VARCHAR(3) NOT NULL, target VARCHAR(3) NOT NULL );'
+    sql15 = """
+        CREATE TABLE t (
+            a TEXT NOT NULL,
+            b TEXT NOT NULL,
+            PRIMARY KEY (a),
+            FOREIGN KEY (a) REFERENCES other(id),
+            FOREIGN KEY (b) REFERENCES other(id)
+        )
+    """
 
     def test_get_create_table_info1(self):
         info = get_create_table_info(tokenize(self.sql1))
@@ -307,6 +316,14 @@ class Test_GetCreateTableInfo(TestCase, TestCasePy27Features):
             0: ('id', 'VARCHAR', 'NOT NULL'),
             1: ('source', 'VARCHAR', 'NOT NULL'),
             2: ('target', 'VARCHAR', 'NOT NULL'),
+        })])
+
+    def test_get_create_table_info15(self):
+        info = get_create_table_info(tokenize(self.sql15))
+
+        self.assertEqual(info, [('t', {
+            0: ('a', 'TEXT', 'NOT NULL'),
+            1: ('b', 'TEXT', 'NOT NULL'),
         })])
 
     def test_get_create_table_info_errors(self):

--- a/tox.windows.ini
+++ b/tox.windows.ini
@@ -12,6 +12,7 @@ deps=
 commands=
   python {envdir}\scripts\sqlformat --version  # Sanity check.
   py.test --cov=sqlparse tests
+  python tests\test_doctests.py
 
 [testenv:py34]
 changedir={envdir}
@@ -21,3 +22,4 @@ commands=
   xcopy.exe /E /I {toxinidir}\tests tests
   2to3.py -w --no-diffs -n tests/
   py.test --cov={envdir}\lib\site-packages\sqlparse tests
+  python tests\test_doctests.py

--- a/tox.windows.ini
+++ b/tox.windows.ini
@@ -1,0 +1,23 @@
+# Tox config for Windows
+# TODO: gives warnings about programs not installed in virtualenv -> they can be ignored
+
+[tox]
+envlist=py34
+#envlist=py26,py27,py32,py33,py34,pypy
+
+[testenv]
+deps=
+  pytest
+  pytest-cov
+commands=
+  python {envdir}\scripts\sqlformat --version  # Sanity check.
+  py.test --cov=sqlparse tests
+
+[testenv:py34]
+changedir={envdir}
+commands=
+  python scripts\sqlformat --version  # Sanity check.
+  cmd.exe /C "del /S /Q tests"
+  xcopy.exe /E /I {toxinidir}\tests tests
+  2to3.py -w --no-diffs -n tests/
+  py.test --cov={envdir}\lib\site-packages\sqlparse tests


### PR DESCRIPTION
Usage:

``` python
from sqlparse import lexer
from sqlparse.functions import get_create_table_info
from pprint import pprint
pprint(get_create_table_info(lexer.tokenize('''
    CREATE TABLE customer (
        id BIGINT PRIMARY KEY NOT NULL,
        name VARCHAR(255) NOT NULL,
        address TEXT NULL
    )
''')))
```

prints:

```
[('customer',
    {0: ('id', 'BIGINT', 'NOT NULL'),
     1: ('name', 'VARCHAR', 'NOT NULL'),
     2: ('address', 'TEXT', 'NULL')})]
```
