### PR TITLE
Speed up grouping of indentifiers

### DIFF
--- a/sqlparse/engine/grouping.py
+++ b/sqlparse/engine/grouping.py
@@ -188,9 +188,12 @@ def group_identifier(tlist):
         t1 = tl.token_next_by_type(
             i, (T.String.Symbol, T.Name, T.Literal.Number.Integer,
                 T.Literal.Number.Float))
-        t2 = tl.token_next_by_instance(i, (sql.Function, sql.Parenthesis))
+
+        i1 = tl.token_index(t1) if t1 else None
+        t2_end = None if i1 is None else i1 + 1
+        t2 = tl.token_next_by_instance(i, (sql.Function, sql.Parenthesis), end=t2_end)
+
         if t1 and t2:
-            i1 = tl.token_index(t1)
             i2 = tl.token_index(t2)
             if i1 > i2:
                 return t2

--- a/sqlparse/sql.py
+++ b/sqlparse/sql.py
@@ -343,8 +343,16 @@ class TokenList(Token):
                 continue
             return self.tokens[idx]
 
-    def token_index(self, token):
+    def token_index(self, token, start=0):
         """Return list index of token."""
+        if start > 0:
+            # Performing `index` manually is much faster when starting in the middle
+            # of the list of tokens and expecting to find the token near to the starting
+            # index.
+            for i in xrange(start, len(self.tokens)):
+                if self.tokens[i] == token:
+                    return i
+            return -1
         return self.tokens.index(token)
 
     def tokens_between(self, start, end, exclude_end=False):

--- a/sqlparse/sql.py
+++ b/sqlparse/sql.py
@@ -256,7 +256,7 @@ class TokenList(Token):
                 continue
             return token
 
-    def token_next_by_instance(self, idx, clss):
+    def token_next_by_instance(self, idx, clss, end=None):
         """Returns the next token matching a class.
 
         *idx* is where to start searching in the list of child tokens.
@@ -267,7 +267,7 @@ class TokenList(Token):
         if not isinstance(clss, (list, tuple)):
             clss = (clss,)
 
-        for token in self.tokens[idx:]:
+        for token in self.tokens[idx:end]:
             if isinstance(token, clss):
                 return token
 


### PR DESCRIPTION
This should help with https://github.com/andialbrecht/sqlparse/issues/135 and https://github.com/andialbrecht/sqlparse/issues/199. Using the file uploaded to https://github.com/andialbrecht/sqlparse/issues/199, this branch reformats the sql 10x faster:
```
# master
time sqlformat -r ./test.sql -o /dev/null
sqlformat -r ./test.sql -o /dev/null  9.61s user 0.03s system 99% cpu 9.663 total

# this PR
time sqlformat -r ./test.sql -o /dev/null
sqlformat -r ./test.sql -o /dev/null  0.95s user 0.02s system 99% cpu 0.979 total
```