### PR TITLE
Fix PendingDeprecationWarning on Python 3.5.

### DIFF
--- a/sqlparse/engine/grouping.py
+++ b/sqlparse/engine/grouping.py
@@ -180,7 +180,7 @@ def group_identifier(tlist):
             else:
                 if isinstance(t, sql.Comment) and t.is_multiline():
                     yield t
-                raise StopIteration
+                return
 
     def _next_token(tl, i):
         # chooses the next token. if two tokens are found then the


### PR DESCRIPTION
Avoid "PendingDeprecationWarning: generator
'group_identifier.<locals>._consume_cycle' raised StopIteration."

Change in Python: https://www.python.org/dev/peps/pep-0479/