### PR TITLE
Add keyword 'SEQUENCE'

### DIFF
--- a/sqlparse/keywords.py
+++ b/sqlparse/keywords.py
@@ -379,6 +379,7 @@ KEYWORDS = {
     'SECURITY': tokens.Keyword,
     'SELF': tokens.Keyword,
     'SENSITIVE': tokens.Keyword,
+    'SEQUENCE': tokens.Keyword,
     'SERIALIZABLE': tokens.Keyword,
     'SERVER_NAME': tokens.Keyword,
     'SESSION': tokens.Keyword,


### PR DESCRIPTION
For now, sqlparse does not support 'create sequence' statement. Add keyword 'SEQUENCE' to support it.