### PR TITLE
Fix for #227 (get_type() doesn't work for queries that use WITH)

### DIFF
--- a/sqlparse/keywords.py
+++ b/sqlparse/keywords.py
@@ -486,7 +486,7 @@ KEYWORDS = {
     'VOLATILE': tokens.Keyword,
 
     'WHENEVER': tokens.Keyword,
-    'WITH': tokens.Keyword,
+    'WITH': tokens.Keyword.CTE,
     'WITHOUT': tokens.Keyword,
     'WORK': tokens.Keyword,
     'WRITE': tokens.Keyword,

--- a/sqlparse/sql.py
+++ b/sqlparse/sql.py
@@ -487,6 +487,18 @@ class Statement(TokenList):
         elif first_token.ttype in (T.Keyword.DML, T.Keyword.DDL):
             return first_token.normalized
 
+        elif first_token.ttype == T.Keyword.CTE:
+            # The WITH keyword should be followed by either an Identifier or
+            # an IdentifierList containing the CTE definitions;  the actual
+            # DML keyword (e.g. SELECT, INSERT) will follow next.
+            idents = self.token_next(self.token_index(first_token), skip_ws=True)
+            if isinstance(idents, (Identifier, IdentifierList)):
+                dml_keyword = self.token_next(self.token_index(idents), skip_ws=True)
+                if dml_keyword.ttype == T.Keyword.DML:
+                    return dml_keyword.normalized
+            # Hmm, probably invalid syntax, so return unknown.
+            return 'UNKNOWN'
+
         return 'UNKNOWN'
 
 

--- a/sqlparse/tokens.py
+++ b/sqlparse/tokens.py
@@ -75,6 +75,7 @@ Token.Number = Number
 # SQL specific tokens
 DML = Keyword.DML
 DDL = Keyword.DDL
+CTE = Keyword.CTE
 Command = Keyword.Command
 
 Group = Token.Group

--- a/tests/test_regressions.py
+++ b/tests/test_regressions.py
@@ -294,7 +294,13 @@ def test_issue213_leadingws():
 
 
 def test_issue227_gettype_cte():
-    select_stmt = sqlparse.parse('SELECT 1, 2, 3 FROM foo;')[0]
-    assert select_stmt.get_type() == 'SELECT'
-    with_stmt = sqlparse.parse('WITH foo AS (SELECT 1, 2, 3) SELECT * FROM foo;')[0]
-    assert with_stmt.get_type() == 'SELECT'
+    select_stmt = sqlparse.parse('SELECT 1, 2, 3 FROM foo;')
+    assert select_stmt[0].get_type() == 'SELECT'
+    with_stmt = sqlparse.parse('WITH foo AS (SELECT 1, 2, 3) SELECT * FROM foo;')
+    assert with_stmt[0].get_type() == 'SELECT'
+    with2_stmt = sqlparse.parse('''
+        WITH foo AS (SELECT 1 AS abc, 2 AS def),
+             bar AS (SELECT * FROM something WHERE x > 1)
+        INSERT INTO elsewhere SELECT * FROM foo JOIN bar;
+    ''')
+    assert with2_stmt[0].get_type() == 'INSERT'

--- a/tests/test_regressions.py
+++ b/tests/test_regressions.py
@@ -291,3 +291,10 @@ def test_issue212_py2unicode():
 def test_issue213_leadingws():
     sql = " select * from foo"
     assert sqlparse.format(sql, strip_whitespace=True) == "select * from foo"
+
+
+def test_issue227_gettype_cte():
+    select_stmt = sqlparse.parse('SELECT 1, 2, 3 FROM foo;')[0]
+    assert select_stmt.get_type() == 'SELECT'
+    with_stmt = sqlparse.parse('WITH foo AS (SELECT 1, 2, 3) SELECT * FROM foo;')[0]
+    assert with_stmt.get_type() == 'SELECT'


### PR DESCRIPTION
Here's a quick fix for issue #227 which I recently reported.  All of the existing tests still pass and `get_type()` is now correct for my queries.  I'm not 100% happy with the method I used to get the next non-whitespace token...  `self.token_next(self.token_index(...))` seems pretty obtuse.  Is there a better method to use?