### PR TITLE
Recognize USING as a keyword in 'USING(', not just in 'USING ('

### DIFF
--- a/sqlparse/lexer.py
+++ b/sqlparse/lexer.py
@@ -187,7 +187,7 @@ class _Lexer(object):
             # IN is special, it may be followed by a parenthesis, but
             # is never a functino, see issue183
             (r'in\b(?=[ (])?', tokens.Keyword),
-            (r'USING(?=\()', is_keyword),
+            (r'USING(?=\()', tokens.Keyword),
             (r'[^\W\d_]\w*(?=[.(])', tokens.Name),  # see issue39
             (r'[-]?0x[0-9a-fA-F]+', tokens.Number.Hexadecimal),
             (r'[-]?[0-9]*(\.[0-9]+)?[eE][-]?[0-9]+', tokens.Number.Float),

--- a/sqlparse/lexer.py
+++ b/sqlparse/lexer.py
@@ -187,6 +187,7 @@ class _Lexer(object):
             # IN is special, it may be followed by a parenthesis, but
             # is never a functino, see issue183
             (r'in\b(?=[ (])?', tokens.Keyword),
+            (r'USING(?=\()', is_keyword),
             (r'[^\W\d_]\w*(?=[.(])', tokens.Name),  # see issue39
             (r'[-]?0x[0-9a-fA-F]+', tokens.Number.Hexadecimal),
             (r'[-]?[0-9]*(\.[0-9]+)?[eE][-]?[0-9]+', tokens.Number.Float),

--- a/tests/test_grouping.py
+++ b/tests/test_grouping.py
@@ -380,6 +380,13 @@ def test_begin():
     assert isinstance(p.tokens[0], sql.Begin)
 
 
+def test_keyword_followed_by_parenthesis():
+    p = sqlparse.parse('USING(somecol')[0]
+    assert len(p.tokens) == 3
+    assert p.tokens[0].ttype == T.Keyword
+    assert p.tokens[1].ttype == T.Punctuation
+
+
 def test_nested_begin():
     p = sqlparse.parse('BEGIN foo BEGIN bar END END')[0]
     assert len(p.tokens) == 1


### PR DESCRIPTION
These were previously caught by (r'[^\W\d_]\w*(?=[.(])', tokens.Name), so I added a special regex just above that one.