### PR TITLE
CREATE TABLE should not be parsed as Function

### DIFF
--- a/sqlparse/engine/grouping.py
+++ b/sqlparse/engine/grouping.py
@@ -220,6 +220,15 @@ def group_typecasts(tlist):
 
 @recurse(sql.Function)
 def group_functions(tlist):
+    has_create = False
+    has_table = False
+    for tmp_token in tlist.tokens:
+        if tmp_token.value == u'CREATE':
+            has_create = True
+        if tmp_token.value == u'TABLE':
+            has_table = True
+    if has_create and has_table:
+        return
     token = tlist.token_next_by(t=T.Name)
     while token:
         next_ = tlist.token_next(token)


### PR DESCRIPTION
in the examples/column_defs_lowlevel.py
```
SQL = """CREATE TABLE foo (
  id integer primary key,
  title varchar(200) not null,
  description text
);"""
```
this example failed to run correctly, because currently `foo (
  id integer primary key,
  title varchar(200) not null,
  description text
)` part will be parsed as a Function, which actually should be parsed as `Identifier('foo')`, `Token(' ')`, `Parenthesis`, separately.

Not all `Identifier Parenthesis` pairs are functions, they may be `CREATE TABLE (...)`,  `varchar (20)` or others, and might not be grouped as Functions.