### PR TITLE
Convert readthedocs link for their .org -> .io migration for hosted projects

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -36,7 +36,7 @@ Project Page
   https://github.com/andialbrecht/sqlparse
 
 Documentation
-  http://readthedocs.org/docs/sqlparse/en/latest/
+  https://sqlparse.readthedocs.io/en/latest/
 
 Discussions
   http://groups.google.com/group/sqlparse

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -58,4 +58,4 @@ Bug tracker
    https://github.com/andialbrecht/sqlparse/issues
 
 Documentation
-   http://sqlparse.readthedocs.org/
+   https://sqlparse.readthedocs.io/


### PR DESCRIPTION
As per [their blog post of the 27th April](https://blog.readthedocs.com/securing-subdomains/) ‘Securing subdomains’:

> Starting today, Read the Docs will start hosting projects from subdomains on the domain readthedocs.io, instead of on readthedocs.org. This change addresses some security concerns around site cookies while hosting user generated data on the same domain as our dashboard.

Test Plan: Manually visited all the links I’ve modified.