### PR TITLE
Simplify Lexer and Regex

### DIFF
--- a/sqlparse/keywords.py
+++ b/sqlparse/keywords.py
@@ -19,9 +19,11 @@ SQL_REGEX = {
         # $ matches *before* newline, therefore we have two patterns
         # to match Comment.Single
         (r'(--|# ).*?$', tokens.Comment.Single),
+        (r'/\*[\s\S]*?\*/', tokens.Comment.Multiline),
+
         (r'(\r\n|\r|\n)', tokens.Newline),
         (r'\s+', tokens.Whitespace),
-        (r'/\*', tokens.Comment.Multiline, 'multiline-comments'),
+
         (r':=', tokens.Assignment),
         (r'::', tokens.Punctuation),
         (r'[*]', tokens.Wildcard),
@@ -64,12 +66,6 @@ SQL_REGEX = {
         (r'[;:()\[\],\.]', tokens.Punctuation),
         (r'[<>=~!]+', tokens.Operator.Comparison),
         (r'[+/@#%^&|`?^-]+', tokens.Operator),
-    ],
-    'multiline-comments': [
-        (r'/\*', tokens.Comment.Multiline, 'multiline-comments'),
-        (r'\*/', tokens.Comment.Multiline, '#pop'),
-        (r'[^/\*]+', tokens.Comment.Multiline),
-        (r'[/*]', tokens.Comment.Multiline),
     ]}
 
 KEYWORDS = {
@@ -599,7 +595,6 @@ KEYWORDS = {
     'VARCHAR2': tokens.Name.Builtin,
     'VARYING': tokens.Name.Builtin,
 }
-
 
 KEYWORDS_COMMON = {
     'SELECT': tokens.Keyword.DML,

--- a/sqlparse/keywords.py
+++ b/sqlparse/keywords.py
@@ -31,7 +31,6 @@ SQL_REGEX = {
 
         (r'\*', tokens.Wildcard),
 
-        (r'CASE\b', tokens.Keyword),  # extended CASE(foo)
         (r"`(``|[^`])*`", tokens.Name),
         (r"´(´´|[^´])*´", tokens.Name),
         (r'\$([^\W\d]\w*)?\$', tokens.Name.Builtin),
@@ -42,12 +41,11 @@ SQL_REGEX = {
 
         # FIXME(andi): VALUES shouldn't be listed here
         # see https://github.com/andialbrecht/sqlparse/pull/64
-        (r'VALUES', tokens.Keyword),
-        (r'(@|##|#)[^\W\d_]\w+', tokens.Name),
         # IN is special, it may be followed by a parenthesis, but
         # is never a functino, see issue183
-        (r'in\b(?=[ (])?', tokens.Keyword),
-        (r'USING(?=\()', tokens.Keyword),
+        (r'(CASE|IN|VALUES|USING)\b', tokens.Keyword),
+
+        (r'(@|##|#)[^\W\d_]\w+', tokens.Name),
         (r'[^\W\d_]\w*(?=[.(])', tokens.Name),  # see issue39
         (r'[-]?0x[0-9a-fA-F]+', tokens.Number.Hexadecimal),
         (r'[-]?[0-9]*(\.[0-9]+)?[eE][-]?[0-9]+', tokens.Number.Float),

--- a/sqlparse/keywords.py
+++ b/sqlparse/keywords.py
@@ -50,10 +50,12 @@ SQL_REGEX = {
         (r'(?<=\.)[A-Z]\w*', tokens.Name),  # .'Name'
         (r'[A-Z]\w*(?=\()', tokens.Name),  # side effect: change kw to func
 
-        (r'[-]?0x[0-9a-fA-F]+', tokens.Number.Hexadecimal),
-        (r'[-]?[0-9]*(\.[0-9]+)?[eE][-]?[0-9]+', tokens.Number.Float),
-        (r'[-]?[0-9]*\.[0-9]+', tokens.Number.Float),
-        (r'[-]?[0-9]+', tokens.Number.Integer),
+        # TODO: `1.` and `.1` are valid numbers
+        (r'-?0x[\dA-F]+', tokens.Number.Hexadecimal),
+        (r'-?\d*(\.\d+)?E-?\d+', tokens.Number.Float),
+        (r'-?\d*\.\d+', tokens.Number.Float),
+        (r'-?\d+', tokens.Number.Integer),
+
         (r"'(''|\\\\|\\'|[^'])*'", tokens.String.Single),
         # not a real string literal in ANSI SQL:
         (r'(""|".*?[^\\]")', tokens.String.Symbol),

--- a/sqlparse/keywords.py
+++ b/sqlparse/keywords.py
@@ -46,7 +46,11 @@ SQL_REGEX = {
         (r'(CASE|IN|VALUES|USING)\b', tokens.Keyword),
 
         (r'(@|##|#)[A-Z]\w+', tokens.Name),
-        (r'[A-Z]\w*(?=\.)', tokens.Name),  # see issue39
+
+        # see issue #39
+        # Spaces around period `schema . name` are valid identifier
+        # TODO: Spaces before period not implemented
+        (r'[A-Z]\w*(?=\s*\.)', tokens.Name),  # 'Name'   .
         (r'(?<=\.)[A-Z]\w*', tokens.Name),  # .'Name'
         (r'[A-Z]\w*(?=\()', tokens.Name),  # side effect: change kw to func
 

--- a/sqlparse/keywords.py
+++ b/sqlparse/keywords.py
@@ -33,7 +33,7 @@ SQL_REGEX = {
 
         (r"`(``|[^`])*`", tokens.Name),
         (r"´(´´|[^´])*´", tokens.Name),
-        (r'\$([^\W\d]\w*)?\$', tokens.Name.Builtin),
+        (r'\$([_A-Z]\w*)?\$', tokens.Name.Builtin),
 
         (r'\?', tokens.Name.Placeholder),
         (r'%(\(\w+\))?s', tokens.Name.Placeholder),
@@ -45,8 +45,11 @@ SQL_REGEX = {
         # is never a functino, see issue183
         (r'(CASE|IN|VALUES|USING)\b', tokens.Keyword),
 
-        (r'(@|##|#)[^\W\d_]\w+', tokens.Name),
-        (r'[^\W\d_]\w*(?=[.(])', tokens.Name),  # see issue39
+        (r'(@|##|#)[A-Z]\w+', tokens.Name),
+        (r'[A-Z]\w*(?=\.)', tokens.Name),  # see issue39
+        (r'(?<=\.)[A-Z]\w*', tokens.Name),  # .'Name'
+        (r'[A-Z]\w*(?=\()', tokens.Name),  # side effect: change kw to func
+
         (r'[-]?0x[0-9a-fA-F]+', tokens.Number.Hexadecimal),
         (r'[-]?[0-9]*(\.[0-9]+)?[eE][-]?[0-9]+', tokens.Number.Float),
         (r'[-]?[0-9]*\.[0-9]+', tokens.Number.Float),
@@ -61,11 +64,12 @@ SQL_REGEX = {
         (r'((LEFT\s+|RIGHT\s+|FULL\s+)?(INNER\s+|OUTER\s+|STRAIGHT\s+)?'
          r'|(CROSS\s+|NATURAL\s+)?)?JOIN\b', tokens.Keyword),
         (r'END(\s+IF|\s+LOOP|\s+WHILE)?\b', tokens.Keyword),
-        (r'NOT NULL\b', tokens.Keyword),
+        (r'NOT\s+NULL\b', tokens.Keyword),
         (r'CREATE(\s+OR\s+REPLACE)?\b', tokens.Keyword.DDL),
         (r'DOUBLE\s+PRECISION\b', tokens.Name.Builtin),
-        (r'(?<=\.)[^\W\d_]\w*', tokens.Name),
-        (r'[^\W\d]\w*', is_keyword),
+
+        (r'[_A-Z]\w*', is_keyword),
+
         (r'[;:()\[\],\.]', tokens.Punctuation),
         (r'[<>=~!]+', tokens.Operator.Comparison),
         (r'[+/@#%^&|`?^-]+', tokens.Operator),

--- a/sqlparse/keywords.py
+++ b/sqlparse/keywords.py
@@ -17,10 +17,10 @@ def is_keyword(value):
 
 SQL_REGEX = {
     'root': [
-        (r'(--|# ).*?(\r\n|\r|\n)', tokens.Comment.Single),
-        # $ matches *before* newline, therefore we have two patterns
-        # to match Comment.Single
-        (r'(--|# ).*?$', tokens.Comment.Single),
+        (r'(--|# )\+.*?(\r\n|\r|\n|$)', tokens.Comment.Single.Hint),
+        (r'/\*\+[\s\S]*?\*/', tokens.Comment.Multiline.Hint),
+
+        (r'(--|# ).*?(\r\n|\r|\n|$)', tokens.Comment.Single),
         (r'/\*[\s\S]*?\*/', tokens.Comment.Multiline),
 
         (r'(\r\n|\r|\n)', tokens.Newline),

--- a/sqlparse/keywords.py
+++ b/sqlparse/keywords.py
@@ -28,15 +28,18 @@ SQL_REGEX = {
 
         (r':=', tokens.Assignment),
         (r'::', tokens.Punctuation),
-        (r'[*]', tokens.Wildcard),
+
+        (r'\*', tokens.Wildcard),
+
         (r'CASE\b', tokens.Keyword),  # extended CASE(foo)
         (r"`(``|[^`])*`", tokens.Name),
         (r"´(´´|[^´])*´", tokens.Name),
         (r'\$([^\W\d]\w*)?\$', tokens.Name.Builtin),
-        (r'\?{1}', tokens.Name.Placeholder),
-        (r'%\(\w+\)s', tokens.Name.Placeholder),
-        (r'%s', tokens.Name.Placeholder),
+
+        (r'\?', tokens.Name.Placeholder),
+        (r'%(\(\w+\))?s', tokens.Name.Placeholder),
         (r'[$:?]\w+', tokens.Name.Placeholder),
+
         # FIXME(andi): VALUES shouldn't be listed here
         # see https://github.com/andialbrecht/sqlparse/pull/64
         (r'VALUES', tokens.Keyword),

--- a/sqlparse/keywords.py
+++ b/sqlparse/keywords.py
@@ -5,6 +5,8 @@
 # This module is part of python-sqlparse and is released under
 # the BSD License: http://www.opensource.org/licenses/bsd-license.php
 
+import re
+
 from sqlparse import tokens
 
 
@@ -67,6 +69,9 @@ SQL_REGEX = {
         (r'[<>=~!]+', tokens.Operator.Comparison),
         (r'[+/@#%^&|`?^-]+', tokens.Operator),
     ]}
+
+FLAGS = re.IGNORECASE | re.UNICODE
+SQL_REGEX = [(re.compile(rx, FLAGS).match, tt) for rx, tt in SQL_REGEX['root']]
 
 KEYWORDS = {
     'ABORT': tokens.Keyword,

--- a/sqlparse/lexer.py
+++ b/sqlparse/lexer.py
@@ -12,8 +12,6 @@
 # It's separated from the rest of pygments to increase performance
 # and to allow some customizations.
 
-import re
-
 from sqlparse import tokens
 from sqlparse.keywords import SQL_REGEX
 from sqlparse.compat import StringIO, string_types, text_type
@@ -21,16 +19,12 @@ from sqlparse.utils import consume
 
 
 class Lexer(object):
-    flags = re.IGNORECASE | re.UNICODE
+    """Lexer
+    Empty class. Leaving for back-support
+    """
 
-    def __init__(self):
-        self._tokens = []
-
-        for tdef in SQL_REGEX['root']:
-            rex = re.compile(tdef[0], self.flags).match
-            self._tokens.append((rex, tdef[1]))
-
-    def get_tokens(self, text, encoding=None):
+    @staticmethod
+    def get_tokens(text, encoding=None):
         """
         Return an iterable of (tokentype, value) pairs generated from
         `text`. If `unfiltered` is set to `True`, the filtering mechanism
@@ -57,7 +51,7 @@ class Lexer(object):
 
         iterable = enumerate(text)
         for pos, char in iterable:
-            for rexmatch, action in self._tokens:
+            for rexmatch, action in SQL_REGEX:
                 m = rexmatch(text, pos)
 
                 if not m:


### PR DESCRIPTION
Changes:

+ Alternate form to fix multiline comments - Slight behavior change
+ Refactored re to compile once instead of each time tokenize called
+ Simplified regex strings
+ Added Comment.Hint for Oracle