### PR TITLE
Track positions of tokens

### DIFF
--- a/sqlparse/engine/statement_splitter.py
+++ b/sqlparse/engine/statement_splitter.py
@@ -112,7 +112,7 @@ class StatementSplitter(object):
             self.level += self._change_splitlevel(ttype, value)
 
             # Append the token to the current statement
-            self.tokens.append(sql.Token(ttype, value))
+            self.tokens.append(sql.Token(ttype, value, row, col))
 
             # Check if we get the end of a statement
             if self.level <= 0 and ttype is T.Punctuation and value == ';':

--- a/sqlparse/engine/statement_splitter.py
+++ b/sqlparse/engine/statement_splitter.py
@@ -97,7 +97,7 @@ class StatementSplitter(object):
         EOS_TTYPE = T.Whitespace, T.Comment.Single
 
         # Run over all stream tokens
-        for ttype, value in stream:
+        for ttype, value, row, col in stream:
             # Yield token if we finished a statement and there's no whitespaces
             # It will count newline token as a non whitespace. In this context
             # whitespace ignores newlines.

--- a/sqlparse/filters/tokens.py
+++ b/sqlparse/filters/tokens.py
@@ -17,10 +17,10 @@ class _CaseFilter(object):
         self.convert = getattr(text_type, case)
 
     def process(self, stream):
-        for ttype, value in stream:
+        for ttype, value, row, col in stream:
             if ttype in self.ttype:
                 value = self.convert(value)
-            yield ttype, value
+            yield ttype, value, row, col
 
 
 class KeywordCaseFilter(_CaseFilter):
@@ -31,10 +31,10 @@ class IdentifierCaseFilter(_CaseFilter):
     ttype = T.Name, T.String.Symbol
 
     def process(self, stream):
-        for ttype, value in stream:
+        for ttype, value, row, col in stream:
             if ttype in self.ttype and value.strip()[0] != '"':
                 value = self.convert(value)
-            yield ttype, value
+            yield ttype, value, row, col
 
 
 class TruncateStringFilter(object):
@@ -43,9 +43,9 @@ class TruncateStringFilter(object):
         self.char = char
 
     def process(self, stream):
-        for ttype, value in stream:
+        for ttype, value, row, col in stream:
             if ttype != T.Literal.String.Single:
-                yield ttype, value
+                yield ttype, value, row, col
                 continue
 
             if value[:2] == "''":
@@ -57,4 +57,4 @@ class TruncateStringFilter(object):
 
             if len(inner) > self.width:
                 value = ''.join((quote, inner[:self.width], self.char, quote))
-            yield ttype, value
+            yield ttype, value, row, col

--- a/sqlparse/sql.py
+++ b/sqlparse/sql.py
@@ -24,15 +24,18 @@ class Token(object):
     the type of the token.
     """
 
-    __slots__ = ('value', 'ttype', 'parent', 'normalized', 'is_keyword')
+    __slots__ = ('value', 'ttype', 'parent', 'normalized', 'is_keyword',
+                 'row', 'col')
 
-    def __init__(self, ttype, value):
+    def __init__(self, ttype, value, row=None, col=None):
         value = text_type(value)
         self.value = value
         self.ttype = ttype
         self.parent = None
         self.is_keyword = ttype in T.Keyword
         self.normalized = value.upper() if self.is_keyword else value
+        self.row = row
+        self.col = col
 
     def __str__(self):
         return self.value
@@ -141,7 +144,12 @@ class TokenList(Token):
     def __init__(self, tokens=None):
         self.tokens = tokens or []
         [setattr(token, 'parent', self) for token in tokens]
-        super(TokenList, self).__init__(None, text_type(self))
+        if self.tokens:
+            # Assumption: Start of TokenList is start of first token.
+            row, col = self.tokens[0].row, self.tokens[0].col
+        else:
+            row, col = None, None
+        super(TokenList, self).__init__(None, text_type(self), row, col)
 
     def __str__(self):
         return ''.join(token.value for token in self.flatten())

--- a/sqlparse/sql.py
+++ b/sqlparse/sql.py
@@ -22,6 +22,11 @@ class Token(object):
     It represents a single token and has two instance attributes:
     ``value`` is the unchange value of the token and ``ttype`` is
     the type of the token.
+
+    Additionally, in case the ``Token`` object has been created by
+    parsing an SQL string, the attributes ``row`` and ``col``
+    correspond to the position of the start of the token in the
+    original data source.
     """
 
     __slots__ = ('value', 'ttype', 'parent', 'normalized', 'is_keyword',

--- a/tests/test_position_tracking.py
+++ b/tests/test_position_tracking.py
@@ -1,0 +1,50 @@
+import unittest
+
+import sqlparse
+from sqlparse import lexer
+from sqlparse import tokens as T
+
+
+class TestPositionTracking(unittest.TestCase):
+
+    def setUp(self):
+        #           012345678901234567
+        self.sql = 'select * from foo;'
+        self.results = [  # List of (type, value, row, col) tuples
+            (T.Keyword.DML, u'select', 1, 0),
+            (T.Text.Whitespace, u' ', 1, 6),
+            (T.Wildcard, u'*', 1, 7),
+            (T.Text.Whitespace, u' ', 1, 8),
+            (T.Keyword, u'from', 1, 9),
+            (T.Text.Whitespace, u' ', 1, 13),
+            (T.Name, u'foo', 1, 14),
+            (T.Punctuation, u';', 1, 17),
+        ]
+
+    def test_tokenizer_yields_positions(self):
+        tokens = list(lexer.tokenize(self.sql))
+        self.assertEqual(len(tokens), 8)
+        self.assertEqual(tokens, self.results)
+
+    def test_parser_augments_tokens_with_positions(self):
+        t = sqlparse.parse(self.sql)[0].tokens
+        self.assertEqual(len(t), 8)
+        for idx in range(8):
+            # Only test positions, the rest is already tested elsewhere.
+            self.assertEqual(t[idx].row, self.results[idx][2])
+            self.assertEqual(t[idx].col, self.results[idx][3])
+
+    def test_parser_multiline_statement(self):
+        #      01234567| 01234567| 01234567890123
+        sql = 'select *\nfrom foo\nwhere bar > 0;'
+        t = sqlparse.parse(sql)[0].tokens
+
+        self.assertEqual(len(t), 9, t)
+        self.assertEqual(t[8].value, u'where bar > 0;')
+        self.assertEqual(t[8].row, 3)
+        self.assertEqual(t[8].col, 0)
+
+        self.assertEqual(len(t[8].tokens), 4)
+        self.assertEqual(t[8].tokens[3].ttype, T.Punctuation)
+        self.assertEqual(t[8].tokens[3].row, 3)
+        self.assertEqual(t[8].tokens[3].col, 13)

--- a/tests/test_tokenize.py
+++ b/tests/test_tokenize.py
@@ -20,15 +20,15 @@ class TestTokenize(unittest.TestCase):
         self.assert_(isinstance(stream, types.GeneratorType))
         tokens = list(stream)
         self.assertEqual(len(tokens), 8)
-        self.assertEqual(len(tokens[0]), 2)
-        self.assertEqual(tokens[0], (T.Keyword.DML, u'select'))
-        self.assertEqual(tokens[-1], (T.Punctuation, u';'))
+        self.assertEqual(len(tokens[0]), 4)
+        self.assertEqual(tokens[0], (T.Keyword.DML, u'select', 1, 0))
+        self.assertEqual(tokens[-1], (T.Punctuation, u';', 1, 17))
 
     def test_backticks(self):
         s = '`foo`.`bar`'
         tokens = list(lexer.tokenize(s))
         self.assertEqual(len(tokens), 3)
-        self.assertEqual(tokens[0], (T.Name, u'`foo`'))
+        self.assertEqual(tokens[0], (T.Name, u'`foo`', 1, 0))
 
     def test_linebreaks(self):  # issue1
         s = 'foo\nbar\n'


### PR DESCRIPTION
In some cases (error reporting, syntax highlighting), it might be desired to know the location of the tokens w.r.t. the original input.
