### PR TITLE
Returning clause ends where clause

### DIFF
--- a/sqlparse/sql.py
+++ b/sqlparse/sql.py
@@ -529,7 +529,7 @@ class Where(TokenList):
     """A WHERE clause."""
     M_OPEN = T.Keyword, 'WHERE'
     M_CLOSE = T.Keyword, ('ORDER', 'GROUP', 'LIMIT', 'UNION', 'EXCEPT',
-                          'HAVING')
+                          'HAVING', 'RETURNING')
 
 
 class Case(TokenList):

--- a/tests/test_grouping.py
+++ b/tests/test_grouping.py
@@ -188,6 +188,14 @@ def test_grouping_where():
     assert isinstance(p.tokens[-1].tokens[0].tokens[-2], sql.Where)
 
 
+def test_returning_kw_ends_where_clause():
+    s = 'delete from foo where x > y returning z'
+    p = sqlparse.parse(s)[0]
+    assert isinstance(p.tokens[6], sql.Where)
+    assert p.tokens[7].ttype == T.Keyword
+    assert p.tokens[7].value == 'returning'
+
+
 def test_grouping_typecast():
     s = 'select foo::integer from bar'
     p = sqlparse.parse(s)[0]


### PR DESCRIPTION
Related to #267. Previously with `delete from foo where x > y returning x` the `returning x` part was subsumed into the where clause