### PR TITLE
Update Config files

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -5,7 +5,7 @@ root = true
 [*]
 indent_style = space
 indent_size = 4
-end_of_line = crlf
+end_of_line = lf
 charset = utf-8
 insert_final_newline = true
 trim_trailing_whitespace = true
@@ -18,6 +18,3 @@ trim_trailing_whitespace = true
 
 [{Makefile,*.bat}]
 indent_style = tab
-
-[*.md]
-trim_trailing_whitespace = false

--- a/.travis.yml
+++ b/.travis.yml
@@ -23,6 +23,7 @@ matrix:
     allow_failures:
         - env: TOXENV=py26
         - env: TOXENV=py36
+        - env: TOXENV=pypy3
         - python: "nightly"
 
 install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,11 +15,14 @@ matrix:
     fast_finish: true
 
     include:
-        - python: "nightly"
+        - python: 3.6-dev
           env: TOXENV=py36
+        - python: "nightly"
+          env: TOXENV=py37
 
     allow_failures:
         - env: TOXENV=py26
+        - env: TOXENV=py36
         - python: "nightly"
 
 install:

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -2,10 +2,10 @@ recursive-include docs source/*
 include docs/sqlformat.1
 include docs/Makefile
 recursive-include tests *.py *.sql
-include COPYING
+include LICENSE
 include TODO
 include AUTHORS
 include CHANGELOG
 include Makefile
-include pytest.ini
+include setup.cfg
 include tox.ini

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,8 +1,10 @@
 [wheel]
 universal = 1
 
-[pytest]
+[tool:pytest]
 xfail_strict = True
+addopts = -v -r fxX
+# -r fxX: show extra test summary info for: (f)ailed, (x)failed, (X)passed
 
 [flake8]
 exclude =

--- a/tox.ini
+++ b/tox.ini
@@ -1,4 +1,5 @@
 [tox]
+skip_missing_interpreters = True
 envlist =
     py27,
     py33,

--- a/tox.ini
+++ b/tox.ini
@@ -6,6 +6,7 @@ envlist =
     py34,
     py35,
     py36,
+    py37,
     pypy,
     pypy3,
     flake8


### PR DESCRIPTION
Update various config files.
- Fix Python 3.6 interpreter
- Add Python 3.7 interpreter
- Add Pypy3 to allowed failures
- Update Manifest
- Update editorconfig
- Update pytest ini header
- Make pytest output verbose (iffy on this change)
- Allow tox to pass when interpreters are missing
