### PR TITLE
Fix _flatten_up_to_token() to be PEP 479 compatible

### DIFF
--- a/sqlparse/filters/reindent.py
+++ b/sqlparse/filters/reindent.py
@@ -30,7 +30,7 @@ class ReindentFilter(object):
 
         for t in self._curr_stmt.flatten():
             if t == token:
-                raise StopIteration
+                break
             yield t
 
     @property


### PR DESCRIPTION
Fixes warning during tests:

PendingDeprecationWarning: generator 'ReindentFilter._flatten_up_to_token' raised StopIteration

PEP 479 documentation: https://www.python.org/dev/peps/pep-0479/