### PR TITLE
adds '1.' option support for float numbers regex

### DIFF
--- a/sqlparse/keywords.py
+++ b/sqlparse/keywords.py
@@ -53,13 +53,14 @@ SQL_REGEX = {
         # Spaces around period `schema . name` are valid identifier
         # TODO: Spaces before period not implemented
         (r'[A-Z]\w*(?=\s*\.)', tokens.Name),  # 'Name'   .
+        # FIXME(atronah): never match,
+        # because `re.match` doesn't work with lookbehind regexp feature
         (r'(?<=\.)[A-Z]\w*', tokens.Name),  # .'Name'
         (r'[A-Z]\w*(?=\()', tokens.Name),  # side effect: change kw to func
 
-        # TODO: `1.` and `.1` are valid numbers
         (r'-?0x[\dA-F]+', tokens.Number.Hexadecimal),
         (r'-?\d*(\.\d+)?E-?\d+', tokens.Number.Float),
-        (r'-?\d*\.\d+', tokens.Number.Float),
+        (r'-?(\d+(\.\d*)|\.\d+)', tokens.Number.Float),
         (r'-?\d+', tokens.Number.Integer),
 
         (r"'(''|\\\\|\\'|[^'])*'", tokens.String.Single),

--- a/tests/test_keywords.py
+++ b/tests/test_keywords.py
@@ -1,0 +1,14 @@
+# -*- coding: utf-8 -*-
+import pytest
+
+from sqlparse import tokens
+from sqlparse.keywords import SQL_REGEX
+
+
+class TestSQLREGEX:
+    @pytest.mark.parametrize('number', ['1.0', '-1.0',
+                                        '1.', '-1.',
+                                        '.1', '-.1'])
+    def test_float_numbers(self, number):
+        ttype = next(tt for action, tt in SQL_REGEX if action(number))
+        assert tokens.Number.Float == ttype


### PR DESCRIPTION
tried to solve one of todo from keywords.py (with creating test_keywords.py script)
added fixme mark for regex that never match.
