### PR TITLE
Option to indent after first line

### DIFF
--- a/sqlparse/cli.py
+++ b/sqlparse/cli.py
@@ -102,6 +102,13 @@ def create_parser():
         help='indentation width (defaults to 2 spaces)')
 
     group.add_argument(
+        '--indent_after_first',
+        dest='indent_after_first',
+        action='store_true',
+        default=False,
+        help='indent after first line of statement (e.g. SELECT)')
+
+    group.add_argument(
         '-a', '--reindent_aligned',
         action='store_true',
         default=False,

--- a/sqlparse/filters/reindent.py
+++ b/sqlparse/filters/reindent.py
@@ -12,7 +12,7 @@ from sqlparse.utils import offset, indent
 
 class ReindentFilter(object):
     def __init__(self, width=2, char=' ', wrap_after=0, n='\n',
-                 comma_first=False, indent_after_first = False):
+                 comma_first=False, indent_after_first=False):
         self.n = n
         self.width = width
         self.char = char

--- a/sqlparse/filters/reindent.py
+++ b/sqlparse/filters/reindent.py
@@ -12,11 +12,11 @@ from sqlparse.utils import offset, indent
 
 class ReindentFilter(object):
     def __init__(self, width=2, char=' ', wrap_after=0, n='\n',
-                 comma_first=False):
+                 comma_first=False, indent_after_first = False):
         self.n = n
         self.width = width
         self.char = char
-        self.indent = 0
+        self.indent = 1 if indent_after_first else 0
         self.offset = 0
         self.wrap_after = wrap_after
         self.comma_first = comma_first

--- a/sqlparse/formatter.py
+++ b/sqlparse/formatter.py
@@ -70,6 +70,11 @@ def validate_options(options):
     elif reindent_aligned:
         options['strip_whitespace'] = True
 
+    indent_after_first = options.get('indent_after_first', False)
+    if indent_after_first not in [True, False]:
+        raise SQLParseError('Invalid value for indent_after_first: '
+                            '{0!r}'.format(indent_after_first))
+
     indent_tabs = options.get('indent_tabs', False)
     if indent_tabs not in [True, False]:
         raise SQLParseError('Invalid value for indent_tabs: '
@@ -153,6 +158,7 @@ def build_filter_stack(stack, options):
         stack.stmtprocess.append(
             filters.ReindentFilter(char=options['indent_char'],
                                    width=options['indent_width'],
+                                   indent_after_first=options['indent_after_first'],
                                    wrap_after=options['wrap_after'],
                                    comma_first=options['comma_first']))
 


### PR DESCRIPTION
(Note: This is not a finished pull request; specifically, the tests are not passing. If you'd be interested to merge, I can work on those. Thanks for a useful tool.)

This adds a command line argument `--indent_after_first` which sets the
indentation of all lines after the first one, e.g. SELECT, UPDATE, etc. For
example:

    $ sqlparse/__main__.py -r sample.sql
    UPDATE foo
      SET a = 1
      WHERE a > 2
        AND a < 10;

    $ sqlparse/__main__.py -r --indent_after_first sample.sql
    UPDATE foo
    SET a = 1
    WHERE a > 2
      AND a < 10;