### PR TITLE
Include license file in the generated wheel package

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,9 @@
 [bdist_wheel]
 universal = 1
 
+[metadata]
+license_file = LICENSE
+
 [tool:pytest]
 xfail_strict = True
 


### PR DESCRIPTION
The wheel package format supports including the license file. This is done using the `[metadata]` section in the `setup.cfg` file. For additional information on this feature, see:

https://wheel.readthedocs.io/en/stable/index.html#including-the-license-in-the-generated-wheel-file