### PR TITLE
Fix unclosed file warnings discovered during tests

### DIFF
--- a/sqlparse/cli.py
+++ b/sqlparse/cli.py
@@ -150,8 +150,11 @@ def main(args=None):
         if PY2:
             data = getreader(args.encoding)(sys.stdin).read()
         else:
-            data = TextIOWrapper(
-                sys.stdin.buffer, encoding=args.encoding).read()
+            wrapper = TextIOWrapper(sys.stdin.buffer, encoding=args.encoding)
+            try:
+                data = wrapper.read()
+            finally:
+                wrapper.detach()
     else:
         try:
             with open(args.filename, 'r', args.encoding) as f:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -115,9 +115,10 @@ def test_encoding_stdin_utf8(filepath, load_file, capfd):
     path = filepath('encoding_utf8.sql')
     expected = load_file('encoding_utf8.sql', 'utf-8')
     old_stdin = sys.stdin
-    sys.stdin = open(path, 'r')
-    sys.stdout.encoding = 'utf-8'
-    sqlparse.cli.main(['-'])
+    with open(path, 'r') as f:
+        sys.stdin = f
+        sys.stdout.encoding = 'utf-8'
+        sqlparse.cli.main(['-'])
     sys.stdin = old_stdin
     out, _ = capfd.readouterr()
     assert out == expected


### PR DESCRIPTION
Appear as:

```
  ResourceWarning: unclosed file ...
```

Always explicitly close files or detach file wrappers.