### PR TITLE
Remove support for EOL Python 3.3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,6 @@ python: 3.5
 env:
     - TOXENV=flake8
     - TOXENV=py27
-    - TOXENV=py33
     - TOXENV=py34
     - TOXENV=py35
 
@@ -12,19 +11,16 @@ matrix:
     fast_finish: true
 
     include:
-        - python: 3.6-dev
+        - python: 3.6
           env: TOXENV=py36
         - python: 3.7-dev
           env: TOXENV=py37
         - python: pypy-5.4
           env: TOXENV=pypy_54
-        - python: pypy3.3-5.2-alpha1
-          env: TOXENV=pypy33
 
     allow_failures:
         - env: TOXENV=py37
         - env: TOXENV=pypy_54
-        - env: TOXENV=pypy33
 
 install:
     - pip install tox codecov

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -5,6 +5,9 @@ Enhancements
 
 * New formatting option "--indent_after_first" (pr345, by johshoff).
 
+Internal Changes
+
+* Remove support for Python 3.3.
 
 Release 0.2.4 (Sep 27, 2017)
 ----------------------------

--- a/setup.py
+++ b/setup.py
@@ -92,7 +92,6 @@ setup(
         'Programming Language :: Python :: 2',
         'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.3',
         'Programming Language :: Python :: 3.4',
         'Programming Language :: Python :: 3.5',
         'Programming Language :: Python :: 3.6',

--- a/setup.py
+++ b/setup.py
@@ -83,6 +83,7 @@ setup(
     description='Non-validating SQL parser',
     long_description=LONG_DESCRIPTION,
     license='BSD',
+    python_requires=">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*",
     classifiers=[
         'Development Status :: 5 - Production/Stable',
         'Intended Audience :: Developers',

--- a/tox.ini
+++ b/tox.ini
@@ -2,13 +2,11 @@
 skip_missing_interpreters = True
 envlist =
     py27
-    py33
     py34
     py35
     py36
     py37
     pypy_54
-    pypy33
     flake8
 
 [testenv]


### PR DESCRIPTION
Python 3.3 is EOL. It is no longer receiving bug fixes, including for
security issues. Python 3.3 has been EOL since 2017-09-29. For
additional details, see:

https://devguide.python.org/#status-of-python-branches

Additionally, pytest has dropped support for Python 3.3 in a recent
version, causing test failures. See:

https://docs.pytest.org/en/latest/changelog.html#pytest-3-3-0-2017-11-23