### PR TITLE
fix trailing semicolon error

### DIFF
--- a/sqlparse/filters/aligned_indent.py
+++ b/sqlparse/filters/aligned_indent.py
@@ -38,7 +38,8 @@ class AlignedIndentFilter(object):
             self._max_kwd_len + offset + indent + self.offset))
 
     def _process_statement(self, tlist):
-        if tlist.tokens[0].is_whitespace and self.indent == 0:
+        if len(tlist.tokens) > 0 and tlist.tokens[0].is_whitespace \
+                and self.indent == 0:
             tlist.tokens.pop(0)
 
         # process the main query body


### PR DESCRIPTION
Issue:  when using `sqlparse` from the command line to parse a sql file with a trailing semicolon with the "reindent_aligned" option, raises `IndexError`.

For instance, given `test.sql`:
```
-- test.sql
select 1;
select 2;
```
The command `$ python -m sqlparse -a test.sql` generates the following stacktrace:
```
$ python -m sqlparse -a test.sql
Traceback (most recent call last):
  File "/Users/circld/miniconda3/lib/python3.6/runpy.py", line 193, in _run_module_as_main
    "__main__", mod_spec)
  File "/Users/circld/miniconda3/lib/python3.6/runpy.py", line 85, in _run_code
    exec(code, run_globals)
  File "/Users/circld/miniconda3/lib/python3.6/site-packages/sqlparse/__main__.py", line 22, in <module>
    sys.exit(main())
  File "/Users/circld/miniconda3/lib/python3.6/site-packages/sqlparse/cli.py", line 179, in main
    s = sqlparse.format(data, **formatter_opts)
  File "/Users/circld/miniconda3/lib/python3.6/site-packages/sqlparse/__init__.py", line 60, in format
    return u''.join(stack.run(sql, encoding))
  File "/Users/circld/miniconda3/lib/python3.6/site-packages/sqlparse/engine/filter_stack.py", line 39, in run
    filter_.process(stmt)
  File "/Users/circld/miniconda3/lib/python3.6/site-packages/sqlparse/filters/aligned_indent.py", line 128, in process
    self._process(stmt)
  File "/Users/circld/miniconda3/lib/python3.6/site-packages/sqlparse/filters/aligned_indent.py", line 125, in _process
    func(tlist)
  File "/Users/circld/miniconda3/lib/python3.6/site-packages/sqlparse/filters/aligned_indent.py", line 41, in _process_statement
    if tlist.tokens[0].is_whitespace and self.indent == 0:
IndexError: list index out of range
```

Added a length check to the `AlignedIndentFilter._process_statement` method, which fixes the issue.

I doubt this is the best way to go about this, but pre- and post-change,  the same tests are passing. Let me know if there's a better place to address this bug.