### PR TITLE
Option: indent all identifiers, including the first one, by width

### DIFF
--- a/sqlparse/cli.py
+++ b/sqlparse/cli.py
@@ -109,6 +109,13 @@ def create_parser():
         help='indent after first line of statement (e.g. SELECT)')
 
     group.add_argument(
+        '--indent_columns',
+        dest='indent_columns',
+        action='store_true',
+        default=False,
+        help='indent all columns by indent_width instead of keyword length')
+
+    group.add_argument(
         '-a', '--reindent_aligned',
         action='store_true',
         default=False,

--- a/sqlparse/filters/reindent.py
+++ b/sqlparse/filters/reindent.py
@@ -12,7 +12,8 @@ from sqlparse.utils import offset, indent
 
 class ReindentFilter(object):
     def __init__(self, width=2, char=' ', wrap_after=0, n='\n',
-                 comma_first=False, indent_after_first=False):
+                 comma_first=False, indent_after_first=False,
+                 indent_columns=False):
         self.n = n
         self.width = width
         self.char = char
@@ -20,6 +21,7 @@ class ReindentFilter(object):
         self.offset = 0
         self.wrap_after = wrap_after
         self.comma_first = comma_first
+        self.indent_columns = indent_columns
         self._curr_stmt = None
         self._last_stmt = None
 
@@ -118,8 +120,12 @@ class ReindentFilter(object):
 
     def _process_identifierlist(self, tlist):
         identifiers = list(tlist.get_identifiers())
-        first = next(identifiers.pop(0).flatten())
-        num_offset = 1 if self.char == '\t' else self._get_offset(first)
+        if self.indent_columns:
+            first = next(identifiers[0].flatten())
+            num_offset = 1 if self.char == '\t' else self.width
+        else:
+            first = next(identifiers.pop(0).flatten())
+            num_offset = 1 if self.char == '\t' else self._get_offset(first)
         if not tlist.within(sql.Function):
             with offset(self, num_offset):
                 position = 0

--- a/sqlparse/formatter.py
+++ b/sqlparse/formatter.py
@@ -56,6 +56,14 @@ def validate_options(options):
         options['truncate_strings'] = truncate_strings
         options['truncate_char'] = options.get('truncate_char', '[...]')
 
+    indent_columns = options.get('indent_columns', False)
+    if indent_columns not in [True, False]:
+        raise SQLParseError('Invalid value for indent_columns: '
+                            '{0!r}'.format(indent_columns))
+    elif indent_columns:
+        options['reindent'] = True  # enforce reindent
+    options['indent_columns'] = indent_columns
+
     reindent = options.get('reindent', False)
     if reindent not in [True, False]:
         raise SQLParseError('Invalid value for reindent: '
@@ -161,6 +169,7 @@ def build_filter_stack(stack, options):
                 char=options['indent_char'],
                 width=options['indent_width'],
                 indent_after_first=options['indent_after_first'],
+                indent_columns=options['indent_columns'],
                 wrap_after=options['wrap_after'],
                 comma_first=options['comma_first']))
 


### PR DESCRIPTION
New format option "indent_columns" [true/false; default: false] to indent all identifiers, including the first one, by indent_width instead of keyword length (a matter of taste, of course):

```
SELECT
    name,
    rank
FROM wherever
GROUP BY
    name
```
I'm not sure this is the right way to implement this. Please advise if you feel it isn't.