### PR TITLE
Update pypi.python.org URL to pypi.org

### DIFF
--- a/docs/source/intro.rst
+++ b/docs/source/intro.rst
@@ -6,7 +6,7 @@ Download & Installation
 -----------------------
 
 The latest released version can be obtained from the `Python Package
-Index (PyPI) <https://pypi.python.org/pypi/sqlparse/>`_. To extract the
+Index (PyPI) <https://pypi.org/project/sqlparse/>`_. To extract the
 install the module system-wide run
 
 .. code-block:: bash


### PR DESCRIPTION
For details on the new PyPI, see the blog post:

https://pythoninsider.blogspot.ca/2018/04/new-pypi-launched-legacy-pypi-shutting.html