### PR TITLE
Use pytest instead of py.test per upstream recommendation, #dropthedot

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -363,7 +363,7 @@ Bug Fixes
 Other
 
 * Documentation updates.
-* Test suite now uses tox and py.test.
+* Test suite now uses tox and pytest.
 * py3k fixes (by vthriller).
 * py3k fixes in setup.py (by Florian Bauer).
 * setup.py now requires distribute (by Florian Bauer).
@@ -379,7 +379,7 @@ Bug Fixes
 * Improve grouping and formatting of concatenated strings (issue53).
 * Improve handling of varchar() (by Mike Amy).
 * Clean up handling of various SQL elements.
-* Switch to py.test and clean up tests.
+* Switch to pytest and clean up tests.
 * Several minor fixes.
 
 Other

--- a/Makefile
+++ b/Makefile
@@ -13,7 +13,7 @@ test:
 	tox
 
 coverage:
-	py.test --cov=sqlparse --cov-report=html --cov-report=term
+	pytest --cov=sqlparse --cov-report=html --cov-report=term
 
 clean:
 	$(PYTHON) setup.py clean

--- a/tox.ini
+++ b/tox.ini
@@ -18,7 +18,7 @@ passenv =
     TRAVIS
 commands =
     sqlformat --version
-    py.test --cov=sqlparse {posargs}
+    pytest --cov=sqlparse {posargs}
 
 [testenv:flake8]
 deps =


### PR DESCRIPTION
http://blog.pytest.org/2016/whats-new-in-pytest-30/
https://twitter.com/hashtag/dropthedot