### PR TITLE
Spelling

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -177,7 +177,7 @@ Bug Fixes
 
 * Fix a regression in get_alias() introduced in 0.1.15 (issue185).
 * Fix a bug in the splitter regarding DECLARE (issue193).
-* sqlformat command line tool doesn't duplicat newlines anymore (issue191).
+* sqlformat command line tool doesn't duplicate newlines anymore (issue191).
 * Don't mix up MySQL comments starting with hash and MSSQL
   temp tables (issue192).
 * Statement.get_type() now ignores comments at the beginning of

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -89,7 +89,7 @@ Bug Fixes
 
 * Fix a regression to parse streams again (issue273, reported and
   test case by gmccreight).
-* Improve Python 2/3 compatibility when using parsestream (isseu190,
+* Improve Python 2/3 compatibility when using parsestream (issue190,
   by phdru).
 * Improve splitting of PostgreSQL functions (issue277).
 

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -443,7 +443,7 @@ Bug Fixes
 
 * Fixed incorrect detection of keyword fragments embed in names (issue7,
   reported and initial patch by andyboyko).
-* Stricter detection of identfier aliases (issue8, reported by estama).
+* Stricter detection of identifier aliases (issue8, reported by estama).
 * WHERE grouping consumed closing parenthesis (issue9, reported by estama).
 * Fixed an issue with trailing whitespaces (reported by Kris).
 * Better detection of escaped single quotes (issue13, reported by

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -315,7 +315,7 @@ Enhancements
 * Add STRAIGHT_JOIN statement (by Yago Riveiro).
 * Function.get_parameters() now returns the parameter if only one parameter is
   given (issue94, by wayne.wuw).
-* sqlparse.split() now removes leading and trailing whitespaces from splitted
+* sqlparse.split() now removes leading and trailing whitespaces from split
   statements.
 * Add USE as keyword token (by mulos).
 * Improve parsing of PEP249-style placeholders (issue103).

--- a/setup.py
+++ b/setup.py
@@ -40,7 +40,7 @@ Splitting SQL statements::
    [u'select * from foo; ', u'select * from bar;']
 
 
-Formatting statemtents::
+Formatting statements::
 
    >>> sql = 'select * from foo where id in (select id from bar);'
    >>> print sqlparse.format(sql, reindent=True, keyword_case='upper')

--- a/sqlparse/filters/others.py
+++ b/sqlparse/filters/others.py
@@ -21,7 +21,7 @@ class StripCommentsFilter(object):
             pidx, prev_ = tlist.token_prev(tidx, skip_ws=False)
             nidx, next_ = tlist.token_next(tidx, skip_ws=False)
             # Replace by whitespace if prev and next exist and if they're not
-            # whitespaces. This doesn't apply if prev or next is a paranthesis.
+            # whitespaces. This doesn't apply if prev or next is a parenthesis.
             if (prev_ is None or next_ is None or
                     prev_.is_whitespace or prev_.match(T.Punctuation, '(') or
                     next_.is_whitespace or next_.match(T.Punctuation, ')')):

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -32,7 +32,7 @@ def test_valid_args(filepath):
     assert sqlparse.cli.main([path, '-r']) is not None
 
 
-def test_invalid_choise(filepath):
+def test_invalid_choice(filepath):
     path = filepath('function.sql')
     with pytest.raises(SystemExit):
         sqlparse.cli.main([path, '-l', 'Spanish'])

--- a/tests/test_regressions.py
+++ b/tests/test_regressions.py
@@ -250,8 +250,8 @@ def test_issue193_splitting_function():
                  RETURN x;
                 END;
                 SELECT * FROM a.b;"""
-    splitted = sqlparse.split(sql)
-    assert len(splitted) == 2
+    statements = sqlparse.split(sql)
+    assert len(statements) == 2
 
 
 def test_issue194_splitting_function():
@@ -264,8 +264,8 @@ def test_issue194_splitting_function():
                  RETURN x;
                 END;
                 SELECT * FROM a.b;"""
-    splitted = sqlparse.split(sql)
-    assert len(splitted) == 2
+    statements = sqlparse.split(sql)
+    assert len(statements) == 2
 
 
 def test_issue186_get_type():


### PR DESCRIPTION
I'm trying to use sqlparse...
The most noticable typo was `Formatting statemtents` because it appeared prominently in the documentation.