### PR TITLE
Update the formatting of ON keyword (fixes #308)

### DIFF
--- a/sqlparse/filters/reindent.py
+++ b/sqlparse/filters/reindent.py
@@ -55,7 +55,7 @@ class ReindentFilter(object):
     def _next_token(self, tlist, idx=-1):
         split_words = ('FROM', 'STRAIGHT_JOIN$', 'JOIN$', 'AND', 'OR',
                        'GROUP', 'ORDER', 'UNION', 'VALUES',
-                       'SET', 'BETWEEN', 'EXCEPT', 'HAVING', 'LIMIT')
+                       'SET', 'BETWEEN', 'EXCEPT', 'HAVING', 'LIMIT', 'ON')
         m_split = T.Keyword, split_words, True
         tidx, token = tlist.token_next_by(m=m_split, idx=idx)
 

--- a/tests/test_format.py
+++ b/tests/test_format.py
@@ -387,22 +387,38 @@ class TestFormatReindent(object):
         assert f(s) == '\n'.join([
             'select *',
             'from foo',
-            'join bar on 1 = 2'])
+            'join bar',
+            'on 1 = 2'])
         s = 'select * from foo inner join bar on 1 = 2'
         assert f(s) == '\n'.join([
             'select *',
             'from foo',
-            'inner join bar on 1 = 2'])
+            'inner join bar',
+            'on 1 = 2'])
         s = 'select * from foo left outer join bar on 1 = 2'
         assert f(s) == '\n'.join([
             'select *',
             'from foo',
-            'left outer join bar on 1 = 2'])
+            'left outer join bar',
+            'on 1 = 2'])
         s = 'select * from foo straight_join bar on 1 = 2'
         assert f(s) == '\n'.join([
             'select *',
             'from foo',
-            'straight_join bar on 1 = 2'])
+            'straight_join bar',
+            'on 1 = 2'])
+        s = 'select * from a inner join ' \
+            '(select * from b where c) as anon ' \
+            'on anon.d = a.d and a.e > 1'
+        assert f(s) == '\n'.join([
+            'select *',
+            'from a',
+            'inner join',
+            '  (select *',
+            '   from b',
+            '   where c) as anon',
+            'on anon.d = a.d',
+            'and a.e > 1'])
 
     def test_identifier_list(self):
         f = lambda sql: sqlparse.format(sql, reindent=True)


### PR DESCRIPTION
This patch changes the ON keyword to be split into a new line.

For example: `select a from foo join bar on a = b`

Before:
```
select a
from foo
join bar on a = b
```

After:
```
select a
from foo
join bar
on a = b
```