### PR TITLE
Enable test package on Python 3.7 (fixes #424)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,10 +4,15 @@ python:
   - "3.4"
   - "3.5"
   - "3.6"
-  # - "3.7" # see https://github.com/travis-ci/travis-ci/issues/9815
   - "nightly"
   - "pypy"
   - "pypy3"
+    
+matrix:
+  include:
+    - python: 3.7
+      dist: xenial
+      sudo: true
 
 install:
   - pip install pytest pytest-cov codecov


### PR DESCRIPTION
Travis now supports Python 3.7. See: https://github.com/travis-ci/travis-ci/issues/9815