### PR TITLE
Remove unnecessary compat shim for bytes

### DIFF
--- a/sqlparse/compat.py
+++ b/sqlparse/compat.py
@@ -27,7 +27,6 @@ if PY3:
     def unicode_compatible(cls):
         return cls
 
-    bytes_type = bytes
     text_type = str
     string_types = (str,)
     from io import StringIO
@@ -40,7 +39,6 @@ elif PY2:
         cls.__str__ = lambda x: x.__unicode__().encode('utf-8')
         return cls
 
-    bytes_type = str
     text_type = unicode
     string_types = (str, unicode,)
     from StringIO import StringIO

--- a/sqlparse/lexer.py
+++ b/sqlparse/lexer.py
@@ -15,7 +15,7 @@
 
 from sqlparse import tokens
 from sqlparse.keywords import SQL_REGEX
-from sqlparse.compat import bytes_type, text_type, file_types
+from sqlparse.compat import text_type, file_types
 from sqlparse.utils import consume
 
 
@@ -43,7 +43,7 @@ class Lexer(object):
 
         if isinstance(text, text_type):
             pass
-        elif isinstance(text, bytes_type):
+        elif isinstance(text, bytes):
             if encoding:
                 text = text.decode(encoding)
             else:


### PR DESCRIPTION
Both Python 2.7 and Python 3 have the type bytes. On Python 2.7, it is
an alias of str, same as was previously defined in compat.py. Makes the
code slightly more compatible with Python 3 style syntax. Observe:

    $ python2
    >>> bytes
    <type 'str'>