### PR TITLE
[tokenizer] Grouping GROUP/ORDER BY

### DIFF
--- a/sqlparse/filters/aligned_indent.py
+++ b/sqlparse/filters/aligned_indent.py
@@ -15,12 +15,12 @@ class AlignedIndentFilter(object):
     join_words = (r'((LEFT\s+|RIGHT\s+|FULL\s+)?'
                   r'(INNER\s+|OUTER\s+|STRAIGHT\s+)?|'
                   r'(CROSS\s+|NATURAL\s+)?)?JOIN\b')
-    by_words = ('GROUP BY', 'ORDER BY')
+    by_words = r'(GROUP|ORDER)\s+BY\b'
     split_words = ('FROM',
-                   join_words, 'ON',
+                   join_words, 'ON', by_words,
                    'WHERE', 'AND', 'OR',
-                   'GROUP BY', 'HAVING', 'LIMIT',
-                   'ORDER BY', 'UNION', 'VALUES',
+                   'HAVING', 'LIMIT',
+                   'UNION', 'VALUES',
                    'SET', 'BETWEEN', 'EXCEPT')
 
     def __init__(self, char=' ', n='\n'):
@@ -106,7 +106,7 @@ class AlignedIndentFilter(object):
             # word as aligner
             if (
                 token.match(T.Keyword, self.join_words, regex=True) or
-                token.match(T.Keyword, ('GROUP BY', 'ORDER BY'))
+                token.match(T.Keyword, self.by_words, regex=True)
             ):
                 token_indent = token.value.split()[0]
             else:
@@ -123,7 +123,7 @@ class AlignedIndentFilter(object):
             pidx, prev_ = tlist.token_prev(idx)
             # HACK: make "group/order by" work. Longer than max_len.
             offset_ = 3 if (
-                prev_ and prev_.match(T.Keyword, ('GROUP BY', 'ORDER BY'))
+                prev_ and prev_.match(T.Keyword, self.by_words, regex=True)
             ) else 0
             with offset(self, offset_):
                 self._process(sgroup)

--- a/sqlparse/filters/reindent.py
+++ b/sqlparse/filters/reindent.py
@@ -54,7 +54,7 @@ class ReindentFilter(object):
 
     def _next_token(self, tlist, idx=-1):
         split_words = ('FROM', 'STRAIGHT_JOIN$', 'JOIN$', 'AND', 'OR',
-                       'GROUP', 'ORDER', 'UNION', 'VALUES',
+                       'GROUP BY', 'ORDER BY', 'UNION', 'VALUES',
                        'SET', 'BETWEEN', 'EXCEPT', 'HAVING', 'LIMIT')
         m_split = T.Keyword, split_words, True
         tidx, token = tlist.token_next_by(m=m_split, idx=idx)

--- a/sqlparse/keywords.py
+++ b/sqlparse/keywords.py
@@ -78,6 +78,8 @@ SQL_REGEX = {
         (r'UNION\s+ALL\b', tokens.Keyword),
         (r'CREATE(\s+OR\s+REPLACE)?\b', tokens.Keyword.DDL),
         (r'DOUBLE\s+PRECISION\b', tokens.Name.Builtin),
+        (r'GROUP\s+BY\b', tokens.Keyword),
+        (r'ORDER\s+BY\b', tokens.Keyword),
 
         (r'[0-9_A-ZÀ-Ü][_$#\w]*', is_keyword),
 

--- a/sqlparse/sql.py
+++ b/sqlparse/sql.py
@@ -534,14 +534,14 @@ class Where(TokenList):
     """A WHERE clause."""
     M_OPEN = T.Keyword, 'WHERE'
     M_CLOSE = T.Keyword, (
-        'ORDER', 'GROUP', 'LIMIT', 'UNION', 'UNION ALL', 'EXCEPT',
+        'ORDER BY', 'GROUP BY', 'LIMIT', 'UNION', 'UNION ALL', 'EXCEPT',
         'HAVING', 'RETURNING', 'INTO')
 
 
 class Having(TokenList):
     """A HAVING clause."""
     M_OPEN = T.Keyword, 'HAVING'
-    M_CLOSE = T.Keyword, ('ORDER', 'LIMIT')
+    M_CLOSE = T.Keyword, ('ORDER BY', 'LIMIT')
 
 
 class Case(TokenList):

--- a/tests/test_grouping.py
+++ b/tests/test_grouping.py
@@ -208,7 +208,7 @@ def test_grouping_where():
     s = 'select * from foo where bar = 1 order by id desc'
     p = sqlparse.parse(s)[0]
     assert str(p) == s
-    assert len(p.tokens) == 14
+    assert len(p.tokens) == 12
 
     s = 'select x from (select y from foo where bar = 1) z'
     p = sqlparse.parse(s)[0]

--- a/tests/test_tokenize.py
+++ b/tests/test_tokenize.py
@@ -183,3 +183,15 @@ def test_parse_identifiers(s):
     token = p.tokens[0]
     assert str(token) == s
     assert isinstance(token, sql.Identifier)
+
+
+def test_parse_group_by():
+    p = sqlparse.parse('GROUP BY')[0]
+    assert len(p.tokens) == 1
+    assert p.tokens[0].ttype is T.Keyword
+
+
+def test_parse_order_by():
+    p = sqlparse.parse('ORDER BY')[0]
+    assert len(p.tokens) == 1
+    assert p.tokens[0].ttype is T.Keyword


### PR DESCRIPTION
Apologies as I'm lacking some historical context but I was wondering why the `GROUP BY` and `ORDER BY` clauses were treated differently than `UNION ALL`, `LEFT JOIN` etc., i.e., being treated as two keywords (`ORDER` and `BY`) rather than one (`ORDER BY`). 

This PR updates the tokenizer to group these keywords together. Note for the aligner I've modified the code so that the aligner is based on the first word (similar to joins) which preserves the current formatting. 