### PR TITLE
Add in slash comment functionality

### DIFF
--- a/sqlparse/keywords.py
+++ b/sqlparse/keywords.py
@@ -21,10 +21,10 @@ def is_keyword(value):
 
 SQL_REGEX = {
     'root': [
-        (r'(--|# )\+.*?(\r\n|\r|\n|$)', tokens.Comment.Single.Hint),
+        (r'(--|//|# )\+.*?(\r\n|\r|\n|$)', tokens.Comment.Single.Hint),
         (r'/\*\+[\s\S]*?\*/', tokens.Comment.Multiline.Hint),
 
-        (r'(--|# ).*?(\r\n|\r|\n|$)', tokens.Comment.Single),
+        (r'(--|//|# ).*?(\r\n|\r|\n|$)', tokens.Comment.Single),
         (r'/\*[\s\S]*?\*/', tokens.Comment.Multiline),
 
         (r'(\r\n|\r|\n)', tokens.Newline),

--- a/tests/files/slashcomment.sql
+++ b/tests/files/slashcomment.sql
@@ -1,0 +1,5 @@
+select * from user;
+//select * from host;
+select * from user;
+select * // foo;
+from foo;

--- a/tests/test_split.py
+++ b/tests/test_split.py
@@ -52,6 +52,22 @@ def test_split_dashcomments_eol(s):
     assert len(stmts) == 1
 
 
+def test_split_slashcomments(load_file):
+    sql = load_file('slashcomment.sql')
+    stmts = sqlparse.parse(sql)
+    assert len(stmts) == 3
+    assert ''.join(str(q) for q in stmts) == sql
+
+
+@pytest.mark.parametrize('s', ['select foo; // comment\n',
+                               'select foo; // comment\r',
+                               'select foo; // comment\r\n',
+                               'select foo; // comment'])
+def test_split_slashcomments_eol(s):
+    stmts = sqlparse.parse(s)
+    assert len(stmts) == 1
+
+
 def test_split_begintag(load_file):
     sql = load_file('begintag.sql')
     stmts = sqlparse.parse(sql)


### PR DESCRIPTION
This could add #456, but doesn't use an optional flag.  Not sure if there's any dialects where double-slashes are used for anything else (floored division like in Python?).