### PR TITLE
Update extract_table_names.py

### DIFF
--- a/examples/extract_table_names.py
+++ b/examples/extract_table_names.py
@@ -35,7 +35,7 @@ def extract_from_part(parsed):
                 for x in extract_from_part(item):
                     yield x
             elif item.ttype is Keyword:
-                raise StopIteration
+                return
             else:
                 yield item
         elif item.ttype is Keyword and item.value.upper() == 'FROM':


### PR DESCRIPTION
PEP 479 Python 3.5+ raises an exception for StopIteration instead of a null return.