### PR TITLE
Add sql_keywords option (fixes #384)

### DIFF
--- a/sqlparse/__init__.py
+++ b/sqlparse/__init__.py
@@ -22,17 +22,17 @@ __version__ = '0.3.1.dev0'
 __all__ = ['engine', 'filters', 'formatter', 'sql', 'tokens', 'cli']
 
 
-def parse(sql, encoding=None):
+def parse(sql, encoding=None, sql_keywords=None):
     """Parse sql and return a list of statements.
 
     :param sql: A string containing one or more SQL statements.
     :param encoding: The encoding of the statement (optional).
     :returns: A tuple of :class:`~sqlparse.sql.Statement` instances.
     """
-    return tuple(parsestream(sql, encoding))
+    return tuple(parsestream(sql, encoding,sql_keywords))
 
 
-def parsestream(stream, encoding=None):
+def parsestream(stream, encoding=None, sql_keywords=None):
     """Parses sql statements from file-like object.
 
     :param stream: A file-like object.
@@ -41,7 +41,7 @@ def parsestream(stream, encoding=None):
     """
     stack = engine.FilterStack()
     stack.enable_grouping()
-    return stack.run(stream, encoding)
+    return stack.run(stream, encoding, sql_keywords)
 
 
 def format(sql, encoding=None, **options):
@@ -61,7 +61,7 @@ def format(sql, encoding=None, **options):
     return u''.join(stack.run(sql, encoding))
 
 
-def split(sql, encoding=None):
+def split(sql, encoding=None, sql_keywords=None):
     """Split *sql* into single statements.
 
     :param sql: A string containing one or more SQL statements.
@@ -69,4 +69,4 @@ def split(sql, encoding=None):
     :returns: A list of strings.
     """
     stack = engine.FilterStack()
-    return [text_type(stmt).strip() for stmt in stack.run(sql, encoding)]
+    return [text_type(stmt).strip() for stmt in stack.run(sql, encoding,sql_keywords)]

--- a/sqlparse/engine/filter_stack.py
+++ b/sqlparse/engine/filter_stack.py
@@ -23,8 +23,8 @@ class FilterStack(object):
     def enable_grouping(self):
         self._grouping = True
 
-    def run(self, sql, encoding=None):
-        stream = lexer.tokenize(sql, encoding)
+    def run(self, sql, encoding=None, sql_keywords=None):
+        stream = lexer.tokenize(sql, encoding, sql_keywords)
         # Process token stream
         for filter_ in self.preprocess:
             stream = filter_.process(stream)

--- a/sqlparse/lexer.py
+++ b/sqlparse/lexer.py
@@ -14,7 +14,7 @@
 # and to allow some customizations.
 
 from sqlparse import tokens
-from sqlparse.keywords import SQL_REGEX
+from sqlparse.keywords import sql_regex
 from sqlparse.compat import text_type, file_types
 from sqlparse.utils import consume
 
@@ -25,7 +25,7 @@ class Lexer(object):
     """
 
     @staticmethod
-    def get_tokens(text, encoding=None):
+    def get_tokens(text, encoding=None, sql_keywords=None):
         """
         Return an iterable of (tokentype, value) pairs generated from
         `text`. If `unfiltered` is set to `True`, the filtering mechanism
@@ -55,9 +55,10 @@ class Lexer(object):
             raise TypeError(u"Expected text or file-like object, got {!r}".
                             format(type(text)))
 
+        regexes = sql_regex(sql_keywords)
         iterable = enumerate(text)
         for pos, char in iterable:
-            for rexmatch, action in SQL_REGEX:
+            for rexmatch, action in regexes:
                 m = rexmatch(text, pos)
 
                 if not m:
@@ -73,10 +74,10 @@ class Lexer(object):
                 yield tokens.Error, char
 
 
-def tokenize(sql, encoding=None):
+def tokenize(sql, encoding=None, sql_dialects=None):
     """Tokenize sql.
 
     Tokenize *sql* using the :class:`Lexer` and return a 2-tuple stream
     of ``(token type, value)`` items.
     """
-    return Lexer().get_tokens(sql, encoding)
+    return Lexer().get_tokens(sql, encoding, sql_dialects)

--- a/tests/test_keywords.py
+++ b/tests/test_keywords.py
@@ -2,7 +2,7 @@
 import pytest
 
 from sqlparse import tokens
-from sqlparse.keywords import SQL_REGEX
+from sqlparse.keywords import sql_regex
 
 
 class TestSQLREGEX:
@@ -10,5 +10,5 @@ class TestSQLREGEX:
                                         '1.', '-1.',
                                         '.1', '-.1'])
     def test_float_numbers(self, number):
-        ttype = next(tt for action, tt in SQL_REGEX if action(number))
+        ttype = next(tt for action, tt in sql_regex() if action(number))
         assert tokens.Number.Float == ttype

--- a/tests/test_regressions.py
+++ b/tests/test_regressions.py
@@ -406,3 +406,12 @@ def test_issue489_tzcasts():
     p = sqlparse.parse('select bar at time zone \'UTC\' as foo')[0]
     assert p.tokens[-1].has_alias() is True
     assert p.tokens[-1].get_alias() == 'foo'
+
+def test_issue384():
+    from sqlparse import keywords
+    p = sqlparse.parse('select bar from instance')[0]
+    assert(p.tokens[-1].ttype == T.Keyword)
+    p = sqlparse.parse('select bar from instance',
+                       sql_keywords=keywords.keywords_map(keywords.KEYWORDS_PLPGSQL,
+                                                          keywords.KEYWORDS_HQL))[0]
+    assert(p.tokens[-1].__class__ == sql.Identifier)


### PR DESCRIPTION
You may pass a dict with a list of specific
dialect keywords to consider.

Default behavior is to consider *all* supported
dialects (oracle, plpgsql, hql).

keywords.keywords_map(*dialects) helper is provided
to merge individual dialect maps.

You may use this to restrict keyword matching
to a specific subset of dialects i.e.
keywords_map(KEYWORDS_HQL,KEYWORDS_PLPGSQL)

See test_regression.py:test_issue384()