### PR TITLE
[sql] Fix TokenList.__init__ when no tokens are provided

### DIFF
--- a/sqlparse/sql.py
+++ b/sqlparse/sql.py
@@ -139,7 +139,7 @@ class TokenList(Token):
 
     def __init__(self, tokens=None):
         self.tokens = tokens or []
-        [setattr(token, 'parent', self) for token in tokens]
+        [setattr(token, 'parent', self) for token in self.tokens]
         super(TokenList, self).__init__(None, text_type(self))
         self.is_group = True
 


### PR DESCRIPTION
This PR fixes an issue where `TokenList()` fails as it's trying to iterate over `tokens` (which is `None`) as opposed to `self.tokens` (which is `[]`).