### PR TITLE
add comma_first option for docs

### DIFF
--- a/docs/source/api.rst
+++ b/docs/source/api.rst
@@ -59,3 +59,8 @@ The :meth:`~sqlparse.format` function accepts the following keyword arguments.
 ``output_format``
   If given the output is additionally formatted to be used as a variable
   in a programming language. Allowed values are "python" and "php".
+
+``comma_first``
+  If ``True`` comma-first notation for column names is used.
+
+ 


### PR DESCRIPTION
I added the explanation about `comma_first` option in `Formatting of SQL Statements` section.