### PR TITLE
Fix a bug that intersect parsed in where clause

### DIFF
--- a/sqlparse/sql.py
+++ b/sqlparse/sql.py
@@ -555,7 +555,8 @@ class Where(TokenList):
     """A WHERE clause."""
     M_OPEN = T.Keyword, 'WHERE'
     M_CLOSE = T.Keyword, (
-        'ORDER BY', 'GROUP BY', 'LIMIT', 'UNION', 'UNION ALL', 'EXCEPT', 'INTERSECT',
+        'ORDER BY', 'GROUP BY', 'LIMIT',
+        'UNION', 'UNION ALL', 'EXCEPT', 'INTERSECT',
         'HAVING', 'RETURNING', 'INTO')
 
 

--- a/sqlparse/sql.py
+++ b/sqlparse/sql.py
@@ -555,7 +555,7 @@ class Where(TokenList):
     """A WHERE clause."""
     M_OPEN = T.Keyword, 'WHERE'
     M_CLOSE = T.Keyword, (
-        'ORDER BY', 'GROUP BY', 'LIMIT', 'UNION', 'UNION ALL', 'EXCEPT',
+        'ORDER BY', 'GROUP BY', 'LIMIT', 'UNION', 'UNION ALL', 'EXCEPT', 'INTERSECT',
         'HAVING', 'RETURNING', 'INTO')
 
 

--- a/tests/test_grouping.py
+++ b/tests/test_grouping.py
@@ -255,13 +255,15 @@ def test_grouping_where():
     assert isinstance(p.tokens[-1].tokens[0].tokens[-2], sql.Where)
 
 
-@pytest.mark.parametrize('s', (
-    'select 1 where 1 = 2 union select 2',
-    'select 1 where 1 = 2 union all select 2',
-))
-def test_grouping_where_union(s):
+@pytest.mark.parametrize('s,compound_operator', [
+    ('select 1 where 1 = 2 union select 2', 'union'),
+    ('select 1 where 1 = 2 union all select 2', 'union all'),
+    ('select 1 where 1 = 2 except select 2', 'except'),
+    ('select 1 where 1 = 2 intersect select 2', 'intersect'),
+])
+def test_compound_operator_ends_where_clause(s, compound_operator):
     p = sqlparse.parse(s)[0]
-    assert p.tokens[5].value.startswith('union')
+    assert p.tokens[5].value == compound_operator
 
 
 def test_returning_kw_ends_where_clause():


### PR DESCRIPTION
`select 1 where 1 = 2 intersect select 2` parsed incorrectly as `select 1 (where 1 = 2 intersect select 2)` before.

It should be `(select 1 where 1 = 2) intersect (select 2)`