### PR TITLE
Parse like and ilike clauses as comparisons

### DIFF
--- a/sqlparse/keywords.py
+++ b/sqlparse/keywords.py
@@ -89,7 +89,7 @@ SQL_REGEX = {
          r'(EXPLODE|INLINE|PARSE_URL_TUPLE|POSEXPLODE|STACK)\b',
          tokens.Keyword),
         (r"(AT|WITH')\s+TIME\s+ZONE\s+'[^']+'", tokens.Keyword.TZCast),
-        (r'(LIKE|ILIKE)\b', tokens.Operator.Comparison),
+        (r'(NOT\s)?(LIKE|ILIKE)\b', tokens.Operator.Comparison),
         (r'[0-9_A-ZÀ-Ü][_$#\w]*', is_keyword),
         (r'[;:()\[\],\.]', tokens.Punctuation),
         (r'[<>=~!]+', tokens.Operator.Comparison),

--- a/sqlparse/keywords.py
+++ b/sqlparse/keywords.py
@@ -89,7 +89,7 @@ SQL_REGEX = {
          r'(EXPLODE|INLINE|PARSE_URL_TUPLE|POSEXPLODE|STACK)\b',
          tokens.Keyword),
         (r"(AT|WITH')\s+TIME\s+ZONE\s+'[^']+'", tokens.Keyword.TZCast),
-        (r'(NOT\s)?(LIKE|ILIKE)\b', tokens.Operator.Comparison),
+        (r'(NOT\s+)?(LIKE|ILIKE)\b', tokens.Operator.Comparison),
         (r'[0-9_A-ZÀ-Ü][_$#\w]*', is_keyword),
         (r'[;:()\[\],\.]', tokens.Punctuation),
         (r'[<>=~!]+', tokens.Operator.Comparison),

--- a/sqlparse/keywords.py
+++ b/sqlparse/keywords.py
@@ -89,8 +89,8 @@ SQL_REGEX = {
          r'(EXPLODE|INLINE|PARSE_URL_TUPLE|POSEXPLODE|STACK)\b',
          tokens.Keyword),
         (r"(AT|WITH')\s+TIME\s+ZONE\s+'[^']+'", tokens.Keyword.TZCast),
+        (r'(LIKE|ILIKE)\b', tokens.Operator.Comparison),
         (r'[0-9_A-ZÀ-Ü][_$#\w]*', is_keyword),
-
         (r'[;:()\[\],\.]', tokens.Punctuation),
         (r'[<>=~!]+', tokens.Operator.Comparison),
         (r'[+/@#%^&|`?^-]+', tokens.Operator),

--- a/tests/test_grouping.py
+++ b/tests/test_grouping.py
@@ -473,6 +473,7 @@ def test_comparison_with_parenthesis():
 
 
 @pytest.mark.parametrize('operator', (
+    '=', '!=', '>', '<', '<=', '>=', '~', '~~', '!~~',
     'LIKE', 'NOT LIKE', 'ILIKE', 'NOT ILIKE',
 ))
 def test_comparison_with_strings(operator):

--- a/tests/test_grouping.py
+++ b/tests/test_grouping.py
@@ -472,7 +472,9 @@ def test_comparison_with_parenthesis():
     assert comp.right.ttype is T.Number.Integer
 
 
-@pytest.mark.parametrize('operator', ['LIKE', 'NOT LIKE', 'ILIKE', 'NOT ILIKE'])
+@pytest.mark.parametrize('operator', (
+    'LIKE', 'NOT LIKE', 'ILIKE', 'NOT ILIKE',
+))
 def test_comparison_with_strings(operator):
     # issue148
     p = sqlparse.parse("foo {0} 'bar'".format(operator))[0]

--- a/tests/test_grouping.py
+++ b/tests/test_grouping.py
@@ -472,9 +472,10 @@ def test_comparison_with_parenthesis():
     assert comp.right.ttype is T.Number.Integer
 
 
-def test_comparison_with_strings():
+@pytest.mark.parametrize('operator', ['LIKE', 'NOT LIKE', 'ILIKE', 'NOT ILIKE'])
+def test_comparison_with_strings(operator):
     # issue148
-    p = sqlparse.parse("foo = 'bar'")[0]
+    p = sqlparse.parse("foo {0} 'bar'".format(operator))[0]
     assert len(p.tokens) == 1
     assert isinstance(p.tokens[0], sql.Comparison)
     assert p.tokens[0].right.value == "'bar'"

--- a/tests/test_tokenize.py
+++ b/tests/test_tokenize.py
@@ -221,7 +221,7 @@ def test_near_like_and_ilike_parsed_appropriately(s):
     p = sqlparse.parse(s)[0]
     assert len(p.tokens) == 1
     assert isinstance(p.tokens[0], sql.Identifier)
-    
+
 
 @pytest.mark.parametrize('s', (
     'AT TIME ZONE \'UTC\'',

--- a/tests/test_tokenize.py
+++ b/tests/test_tokenize.py
@@ -205,6 +205,25 @@ def test_parse_order_by():
 
 
 @pytest.mark.parametrize('s', (
+    "LIKE", "ILIKE", "NOT LIKE", "NOT ILIKE",
+    "NOT   LIKE", "NOT    ILIKE",
+))
+def test_like_and_ilike_parsed_as_comparisons(s):
+    p = sqlparse.parse(s)[0]
+    assert len(p.tokens) == 1
+    assert p.tokens[0].ttype == T.Operator.Comparison
+
+
+@pytest.mark.parametrize('s', (
+    "LIKEaaa", "bILIKE", "aaILIKEbb", "NOTLIKE", "NOTILIKE",
+))
+def test_near_like_and_ilike_parsed_appropriately(s):
+    p = sqlparse.parse(s)[0]
+    assert len(p.tokens) == 1
+    assert isinstance(p.tokens[0], sql.Identifier)
+    
+
+@pytest.mark.parametrize('s', (
     'AT TIME ZONE \'UTC\'',
 ))
 def test_parse_tzcast(s):


### PR DESCRIPTION
This PR addresses #493 by introducing a regex filter to parse the following tokens as comparison operators, rather than keywords: `LIKE`, `ILIKE`, `NOT LIKE`, and `NOT ILIKE`. These terms are regarded as operators by popular SQL engines (e.g. Postgres, MySQL).

@andialbrecht There is a backwards-compatibility consideration here: reclassifying these terms as comparison operators may break preexisting user code that relies on the designation of the terms as keywords. Please let me know what your thoughts are here.