### PR TITLE
[sql] Adding TIMESTAMP to typed literal

### DIFF
--- a/sqlparse/sql.py
+++ b/sqlparse/sql.py
@@ -493,7 +493,8 @@ class TypedLiteral(TokenList):
     """A typed literal, such as "date '2001-09-28'" or "interval '2 hours'"."""
     M_OPEN = T.Name.Builtin, None
     M_CLOSE = T.String.Single, None
-    M_EXTEND = T.Keyword, ("DAY", "HOUR", "MINUTE", "MONTH", "SECOND", "TIMESTAMP", "YEAR")
+    M_EXTEND = T.Keyword, (
+        "DAY", "HOUR", "MINUTE", "MONTH", "SECOND", "TIMESTAMP", "YEAR")
 
 
 class Parenthesis(TokenList):

--- a/sqlparse/sql.py
+++ b/sqlparse/sql.py
@@ -493,7 +493,7 @@ class TypedLiteral(TokenList):
     """A typed literal, such as "date '2001-09-28'" or "interval '2 hours'"."""
     M_OPEN = T.Name.Builtin, None
     M_CLOSE = T.String.Single, None
-    M_EXTEND = T.Keyword, ("DAY", "MONTH", "YEAR", "HOUR", "MINUTE", "SECOND")
+    M_EXTEND = T.Keyword, ("DAY", "MINUTE", "MONTH", "SECOND", "TIMESTAMP", "YEAR")
 
 
 class Parenthesis(TokenList):

--- a/sqlparse/sql.py
+++ b/sqlparse/sql.py
@@ -493,7 +493,7 @@ class TypedLiteral(TokenList):
     """A typed literal, such as "date '2001-09-28'" or "interval '2 hours'"."""
     M_OPEN = T.Name.Builtin, None
     M_CLOSE = T.String.Single, None
-    M_EXTEND = T.Keyword, ("DAY", "MINUTE", "MONTH", "SECOND", "TIMESTAMP", "YEAR")
+    M_EXTEND = T.Keyword, ("DAY", "HOUR", "MINUTE", "MONTH", "SECOND", "TIMESTAMP", "YEAR")
 
 
 class Parenthesis(TokenList):


### PR DESCRIPTION
Adding `TIMESTAMP` which is used as a typed literal for a number of SQL dialects including Oracle and Calcite SQL. 

to: @andialbrecht 