### PR TITLE
[fix] Fixing typed literal regression

### DIFF
--- a/sqlparse/engine/grouping.py
+++ b/sqlparse/engine/grouping.py
@@ -108,7 +108,7 @@ def group_typed_literal(tlist):
     # https://www.postgresql.org/docs/9.1/datatype-datetime.html
     # https://www.postgresql.org/docs/9.1/functions-datetime.html
     def match(token):
-        return token.match(*sql.TypedLiteral.M_OPEN)
+        return imt(token, m=sql.TypedLiteral.M_OPEN)
 
     def match_to_extend(token):
         return isinstance(token, sql.TypedLiteral)

--- a/sqlparse/sql.py
+++ b/sqlparse/sql.py
@@ -491,10 +491,9 @@ class IdentifierList(TokenList):
 
 class TypedLiteral(TokenList):
     """A typed literal, such as "date '2001-09-28'" or "interval '2 hours'"."""
-    M_OPEN = T.Name.Builtin, None
+    M_OPEN = [(T.Name.Builtin, None), (T.Keyword, "TIMESTAMP")]
     M_CLOSE = T.String.Single, None
-    M_EXTEND = T.Keyword, (
-        "DAY", "HOUR", "MINUTE", "MONTH", "SECOND", "TIMESTAMP", "YEAR")
+    M_EXTEND = T.Keyword, ("DAY", "HOUR", "MINUTE", "MONTH", "SECOND", "YEAR")
 
 
 class Parenthesis(TokenList):

--- a/tests/test_grouping.py
+++ b/tests/test_grouping.py
@@ -33,6 +33,12 @@ def test_grouping_assignment(s):
     assert isinstance(parsed.tokens[0], sql.Assignment)
 
 
+@pytest.mark.parametrize('s', ["x > DATE '2020-01-01'", "x > TIMESTAMP '2020-01-01 00:00:00'"])
+def test_grouping_typed_literal(s):
+    parsed = sqlparse.parse(s)[0]
+    assert isinstance(parsed[4], sql.TypedLiteral)
+
+
 @pytest.mark.parametrize('s, a, b', [
     ('select a from b where c < d + e', sql.Identifier, sql.Identifier),
     ('select a from b where c < d + interval \'1 day\'', sql.Identifier, sql.TypedLiteral),


### PR DESCRIPTION
Apologies @andialbrecht I mis interpreted the `M_EXTEND` in #529 as the `TIMESTAMP` should be added to the set of terms which can match the opening of the typed literal. 