### PR TITLE
Run pyupgrade on project to update code to modern Python idioms

### DIFF
--- a/examples/extract_table_names.py
+++ b/examples/extract_table_names.py
@@ -67,4 +67,4 @@ if __name__ == '__main__':
     """
 
     tables = ', '.join(extract_tables(sql))
-    print('Tables: {0}'.format(tables))
+    print('Tables: {}'.format(tables))

--- a/sqlparse/cli.py
+++ b/sqlparse/cli.py
@@ -62,16 +62,16 @@ def create_parser():
         metavar='CHOICE',
         dest='keyword_case',
         choices=_CASE_CHOICES,
-        help='change case of keywords, CHOICE is one of {0}'.format(
-            ', '.join('"{0}"'.format(x) for x in _CASE_CHOICES)))
+        help='change case of keywords, CHOICE is one of {}'.format(
+            ', '.join('"{}"'.format(x) for x in _CASE_CHOICES)))
 
     group.add_argument(
         '-i', '--identifiers',
         metavar='CHOICE',
         dest='identifier_case',
         choices=_CASE_CHOICES,
-        help='change case of identifiers, CHOICE is one of {0}'.format(
-            ', '.join('"{0}"'.format(x) for x in _CASE_CHOICES)))
+        help='change case of identifiers, CHOICE is one of {}'.format(
+            ', '.join('"{}"'.format(x) for x in _CASE_CHOICES)))
 
     group.add_argument(
         '-l', '--language',
@@ -153,7 +153,7 @@ def create_parser():
 
 def _error(msg):
     """Print msg and optionally exit with return code exit_."""
-    sys.stderr.write(u'[ERROR] {0}\n'.format(msg))
+    sys.stderr.write(u'[ERROR] {}\n'.format(msg))
     return 1
 
 
@@ -176,7 +176,7 @@ def main(args=None):
                 data = ''.join(f.readlines())
         except IOError as e:
             return _error(
-                u'Failed to read {0}: {1}'.format(args.filename, e))
+                u'Failed to read {}: {}'.format(args.filename, e))
 
     close_stream = False
     if args.outfile:
@@ -184,7 +184,7 @@ def main(args=None):
             stream = open(args.outfile, 'w', args.encoding)
             close_stream = True
         except IOError as e:
-            return _error(u'Failed to open {0}: {1}'.format(args.outfile, e))
+            return _error(u'Failed to open {}: {}'.format(args.outfile, e))
     else:
         stream = sys.stdout
 
@@ -192,7 +192,7 @@ def main(args=None):
     try:
         formatter_opts = sqlparse.formatter.validate_options(formatter_opts)
     except SQLParseError as e:
-        return _error(u'Invalid options: {0}'.format(e))
+        return _error(u'Invalid options: {}'.format(e))
 
     s = sqlparse.format(data, **formatter_opts)
     stream.write(s)

--- a/sqlparse/filters/right_margin.py
+++ b/sqlparse/filters/right_margin.py
@@ -39,7 +39,7 @@ class RightMarginFilter(object):
                         indent = match.group()
                     else:
                         indent = ''
-                    yield sql.Token(T.Whitespace, '\n{0}'.format(indent))
+                    yield sql.Token(T.Whitespace, '\n{}'.format(indent))
                     self.line = indent
                 self.line += val
             yield token

--- a/sqlparse/formatter.py
+++ b/sqlparse/formatter.py
@@ -17,32 +17,32 @@ def validate_options(options):
     kwcase = options.get('keyword_case')
     if kwcase not in [None, 'upper', 'lower', 'capitalize']:
         raise SQLParseError('Invalid value for keyword_case: '
-                            '{0!r}'.format(kwcase))
+                            '{!r}'.format(kwcase))
 
     idcase = options.get('identifier_case')
     if idcase not in [None, 'upper', 'lower', 'capitalize']:
         raise SQLParseError('Invalid value for identifier_case: '
-                            '{0!r}'.format(idcase))
+                            '{!r}'.format(idcase))
 
     ofrmt = options.get('output_format')
     if ofrmt not in [None, 'sql', 'python', 'php']:
         raise SQLParseError('Unknown output format: '
-                            '{0!r}'.format(ofrmt))
+                            '{!r}'.format(ofrmt))
 
     strip_comments = options.get('strip_comments', False)
     if strip_comments not in [True, False]:
         raise SQLParseError('Invalid value for strip_comments: '
-                            '{0!r}'.format(strip_comments))
+                            '{!r}'.format(strip_comments))
 
     space_around_operators = options.get('use_space_around_operators', False)
     if space_around_operators not in [True, False]:
         raise SQLParseError('Invalid value for use_space_around_operators: '
-                            '{0!r}'.format(space_around_operators))
+                            '{!r}'.format(space_around_operators))
 
     strip_ws = options.get('strip_whitespace', False)
     if strip_ws not in [True, False]:
         raise SQLParseError('Invalid value for strip_whitespace: '
-                            '{0!r}'.format(strip_ws))
+                            '{!r}'.format(strip_ws))
 
     truncate_strings = options.get('truncate_strings')
     if truncate_strings is not None:
@@ -50,17 +50,17 @@ def validate_options(options):
             truncate_strings = int(truncate_strings)
         except (ValueError, TypeError):
             raise SQLParseError('Invalid value for truncate_strings: '
-                                '{0!r}'.format(truncate_strings))
+                                '{!r}'.format(truncate_strings))
         if truncate_strings <= 1:
             raise SQLParseError('Invalid value for truncate_strings: '
-                                '{0!r}'.format(truncate_strings))
+                                '{!r}'.format(truncate_strings))
         options['truncate_strings'] = truncate_strings
         options['truncate_char'] = options.get('truncate_char', '[...]')
 
     indent_columns = options.get('indent_columns', False)
     if indent_columns not in [True, False]:
         raise SQLParseError('Invalid value for indent_columns: '
-                            '{0!r}'.format(indent_columns))
+                            '{!r}'.format(indent_columns))
     elif indent_columns:
         options['reindent'] = True  # enforce reindent
     options['indent_columns'] = indent_columns
@@ -68,27 +68,27 @@ def validate_options(options):
     reindent = options.get('reindent', False)
     if reindent not in [True, False]:
         raise SQLParseError('Invalid value for reindent: '
-                            '{0!r}'.format(reindent))
+                            '{!r}'.format(reindent))
     elif reindent:
         options['strip_whitespace'] = True
 
     reindent_aligned = options.get('reindent_aligned', False)
     if reindent_aligned not in [True, False]:
         raise SQLParseError('Invalid value for reindent_aligned: '
-                            '{0!r}'.format(reindent))
+                            '{!r}'.format(reindent))
     elif reindent_aligned:
         options['strip_whitespace'] = True
 
     indent_after_first = options.get('indent_after_first', False)
     if indent_after_first not in [True, False]:
         raise SQLParseError('Invalid value for indent_after_first: '
-                            '{0!r}'.format(indent_after_first))
+                            '{!r}'.format(indent_after_first))
     options['indent_after_first'] = indent_after_first
 
     indent_tabs = options.get('indent_tabs', False)
     if indent_tabs not in [True, False]:
         raise SQLParseError('Invalid value for indent_tabs: '
-                            '{0!r}'.format(indent_tabs))
+                            '{!r}'.format(indent_tabs))
     elif indent_tabs:
         options['indent_char'] = '\t'
     else:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -71,7 +71,7 @@ def test_stdout(filepath, load_file, capsys):
 
 def test_script():
     # Call with the --help option as a basic sanity check.
-    cmd = "{0:s} -m sqlparse.cli --help".format(sys.executable)
+    cmd = "{:s} -m sqlparse.cli --help".format(sys.executable)
     assert subprocess.call(cmd.split()) == 0
 
 

--- a/tests/test_format.py
+++ b/tests/test_format.py
@@ -663,7 +663,7 @@ def test_format_column_ordering():
 
 
 def test_truncate_strings():
-    sql = "update foo set value = '{0}';".format('x' * 1000)
+    sql = "update foo set value = '{}';".format('x' * 1000)
     formatted = sqlparse.format(sql, truncate_strings=10)
     assert formatted == "update foo set value = 'xxxxxxxxxx[...]';"
     formatted = sqlparse.format(sql, truncate_strings=3, truncate_char='YYY')

--- a/tests/test_grouping.py
+++ b/tests/test_grouping.py
@@ -484,7 +484,7 @@ def test_comparison_with_parenthesis():
 ))
 def test_comparison_with_strings(operator):
     # issue148
-    p = sqlparse.parse("foo {0} 'bar'".format(operator))[0]
+    p = sqlparse.parse("foo {} 'bar'".format(operator))[0]
     assert len(p.tokens) == 1
     assert isinstance(p.tokens[0], sql.Comparison)
     assert p.tokens[0].right.value == "'bar'"
@@ -563,7 +563,7 @@ def test_comparison_with_typed_literal():
 
 @pytest.mark.parametrize('start', ['FOR', 'FOREACH'])
 def test_forloops(start):
-    p = sqlparse.parse('{0} foo in bar LOOP foobar END LOOP'.format(start))[0]
+    p = sqlparse.parse('{} foo in bar LOOP foobar END LOOP'.format(start))[0]
     assert (len(p.tokens)) == 1
     assert isinstance(p.tokens[0], sql.For)
 

--- a/tests/test_regressions.py
+++ b/tests/test_regressions.py
@@ -20,9 +20,9 @@ def test_issue9():
 
 
 def test_issue13():
-    parsed = sqlparse.parse(("select 'one';\n"
-                             "select 'two\\'';\n"
-                             "select 'three';"))
+    parsed = sqlparse.parse("select 'one';\n"
+                            "select 'two\\'';\n"
+                            "select 'three';")
     assert len(parsed) == 3
     assert str(parsed[1]).strip() == "select 'two\\'';"
 
@@ -73,8 +73,8 @@ def test_issue39():
 
 def test_issue40():
     # make sure identifier lists in subselects are grouped
-    p = sqlparse.parse(('SELECT id, name FROM '
-                        '(SELECT id, name FROM bar) as foo'))[0]
+    p = sqlparse.parse('SELECT id, name FROM '
+                       '(SELECT id, name FROM bar) as foo')[0]
     assert len(p.tokens) == 7
     assert p.tokens[2].__class__ == sql.IdentifierList
     assert p.tokens[-1].__class__ == sql.Identifier
@@ -158,9 +158,9 @@ def test_parse_sql_with_binary():
     # See https://github.com/andialbrecht/sqlparse/pull/88
     # digest = '|ËêplL4¡høN{'
     digest = '\x82|\xcb\x0e\xea\x8aplL4\xa1h\x91\xf8N{'
-    sql = "select * from foo where bar = '{0}'".format(digest)
+    sql = "select * from foo where bar = '{}'".format(digest)
     formatted = sqlparse.format(sql, reindent=True)
-    tformatted = "select *\nfrom foo\nwhere bar = '{0}'".format(digest)
+    tformatted = "select *\nfrom foo\nwhere bar = '{}'".format(digest)
     if PY2:
         tformatted = tformatted.decode('unicode-escape')
     assert formatted == tformatted
@@ -337,9 +337,9 @@ def test_issue315_utf8_by_default():
         '\x9b\xb2.'
         '\xec\x82\xac\xeb\x9e\x91\xed\x95\xb4\xec\x9a\x94'
     )
-    sql = "select * from foo where bar = '{0}'".format(digest)
+    sql = "select * from foo where bar = '{}'".format(digest)
     formatted = sqlparse.format(sql, reindent=True)
-    tformatted = "select *\nfrom foo\nwhere bar = '{0}'".format(digest)
+    tformatted = "select *\nfrom foo\nwhere bar = '{}'".format(digest)
     if PY2:
         tformatted = tformatted.decode('utf-8')
     assert formatted == tformatted

--- a/tests/test_tokenize.py
+++ b/tests/test_tokenize.py
@@ -152,7 +152,7 @@ def test_stream_error():
     'INNER JOIN',
     'LEFT INNER JOIN'])
 def test_parse_join(expr):
-    p = sqlparse.parse('{0} foo'.format(expr))[0]
+    p = sqlparse.parse('{} foo'.format(expr))[0]
     assert len(p.tokens) == 3
     assert p.tokens[0].ttype is T.Keyword
 


### PR DESCRIPTION
https://github.com/asottile/pyupgrade

pyupgrade is a tool to automatically upgrade syntax for newer versions
of the language.

Removes unnecessary numbering in `.format()` calls. The numbering is now
automatic.