### PR TITLE
Remove unused pytest-travis-fold test dependency

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -14,9 +14,6 @@ envlist =
 deps =
     pytest
     pytest-cov
-    pytest-travis-fold
-passenv =
-    TRAVIS
 commands =
     sqlformat --version
     pytest --cov=sqlparse {posargs}


### PR DESCRIPTION
The Travis configuration does not executed through tox since
f2a3a6ea356dc38e79c4a025217ed8a3875cabac.