### PR TITLE
Add postgres WINDOW keyword

### DIFF
--- a/sqlparse/keywords.py
+++ b/sqlparse/keywords.py
@@ -833,6 +833,7 @@ KEYWORDS_ORACLE = {
 
 # PostgreSQL Syntax
 KEYWORDS_PLPGSQL = {
+    'WINDOW': tokens.Keyword,
     'PARTITION': tokens.Keyword,
     'OVER': tokens.Keyword,
     'PERFORM': tokens.Keyword,

--- a/tests/test_tokenize.py
+++ b/tests/test_tokenize.py
@@ -202,6 +202,12 @@ def test_parse_order_by():
     assert p.tokens[0].ttype is T.Keyword
 
 
+def test_parse_window_as():
+    p = sqlparse.parse('WINDOW w AS')[0]
+    assert len(p.tokens) == 5
+    assert p.tokens[0].ttype is T.Keyword
+
+
 @pytest.mark.parametrize('s', (
     "LIKE", "ILIKE", "NOT LIKE", "NOT ILIKE",
     "NOT   LIKE", "NOT    ILIKE",


### PR DESCRIPTION
Postgres allows statements of the form:
```sql
SELECT col_1, col_2, SUM(col_3) OVER w
FROM x
WINDOW w AS (PARTITION BY col_1 ORDER BY col_2)
```
where the window is defined once at the end of the query (see [the select documentation](https://www.postgresql.org/docs/9.5/sql-select.html)).

This change adds WINDOW as a postgres keyword, preventing queries like the above being misparsed, with table name and WINDOW being grouped into an single identifier `<Identifier 'x WINDOW'>`.