### PR TITLE
Add Python 3.9 support to tox and travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,9 @@
 language: python
 python:
-  - "3.5"
   - "3.6"
   - "3.7"
   - "3.8"
-  - "3.9-dev"
+  - "3.9"
   - "nightly"
   - "pypy3"
 

--- a/tox.ini
+++ b/tox.ini
@@ -5,6 +5,7 @@ envlist =
     py36
     py37
     py38
+    py39
     pypy3
     flake8
 


### PR DESCRIPTION
Would you consider dropping Python 3.5 (after EOL) support?
And how about introducing GitHub Actions for CI?