### PR TITLE
adding Case expression into elements of Comparison statement

### DIFF
--- a/sqlparse/engine/grouping.py
+++ b/sqlparse/engine/grouping.py
@@ -191,7 +191,7 @@ def group_assignment(tlist):
 
 def group_comparison(tlist):
     sqlcls = (sql.Parenthesis, sql.Function, sql.Identifier,
-              sql.Operation, sql.TypedLiteral)
+              sql.Operation, sql.TypedLiteral, sql.Case)
     ttypes = T_NUMERICAL + T_STRING + T_NAME
 
     def match(token):


### PR DESCRIPTION
For  Case expression is not designated as element of Comparison statement, so assignment in Update statement is parsed incorrect when its right hand value is Case expression.


expected:
```sql
UPDAT xxxx
SET a=CASE
          WHEN 1=1 THEN 0
          ELSE 1
      END,
    b=2,
    c=3
```
acutual:
```sql
UPDAT xxxx
SET a=CASE
          WHEN 1=1 THEN 0
          ELSE 1
      END,
      b=2,
      c=3
```


