### PR TITLE
Add TruncateValueFilter to de-parameterize a sql text

### DIFF
--- a/sqlparse/filters/__init__.py
+++ b/sqlparse/filters/__init__.py
@@ -16,6 +16,7 @@ from sqlparse.filters.output import OutputPythonFilter
 from sqlparse.filters.tokens import KeywordCaseFilter
 from sqlparse.filters.tokens import IdentifierCaseFilter
 from sqlparse.filters.tokens import TruncateStringFilter
+from sqlparse.filters.tokens import TruncateValueFilter
 
 from sqlparse.filters.reindent import ReindentFilter
 from sqlparse.filters.right_margin import RightMarginFilter
@@ -33,6 +34,7 @@ __all__ = [
     'KeywordCaseFilter',
     'IdentifierCaseFilter',
     'TruncateStringFilter',
+    'TruncateValueFilter',
 
     'ReindentFilter',
     'RightMarginFilter',

--- a/sqlparse/filters/tokens.py
+++ b/sqlparse/filters/tokens.py
@@ -65,7 +65,8 @@ class TruncateValueFilter:
 
     def process(self, stream):
         for ttype, value in stream:
-            if ttype != T.Literal.String.Single and ttype not in (T.Literal.Number.Integer, T.Literal.Number.Float, T.Literal.Number.Hexadecimal):
+            if ttype != T.Literal.String.Single and ttype not in (T.Literal.Number.Integer,
+                                                                  T.Literal.Number.Float, T.Literal.Number.Hexadecimal):
                 yield ttype, value
                 continue
 

--- a/sqlparse/filters/tokens.py
+++ b/sqlparse/filters/tokens.py
@@ -57,3 +57,17 @@ class TruncateStringFilter:
             if len(inner) > self.width:
                 value = ''.join((quote, inner[:self.width], self.char, quote))
             yield ttype, value
+
+
+class TruncateValueFilter:
+    def __init__(self):
+        return
+
+    def process(self, stream):
+        for ttype, value in stream:
+            if ttype != T.Literal.String.Single and ttype not in (T.Literal.Number.Integer, T.Literal.Number.Float, T.Literal.Number.Hexadecimal):
+                yield ttype, value
+                continue
+
+            value = '?'
+            yield ttype, value

--- a/sqlparse/filters/tokens.py
+++ b/sqlparse/filters/tokens.py
@@ -65,8 +65,10 @@ class TruncateValueFilter:
 
     def process(self, stream):
         for ttype, value in stream:
-            if ttype != T.Literal.String.Single and ttype not in (T.Literal.Number.Integer,
-                                                                  T.Literal.Number.Float, T.Literal.Number.Hexadecimal):
+            if ttype not in (T.Literal.String.Single,
+                             T.Literal.Number.Integer,
+                             T.Literal.Number.Float,
+                             T.Literal.Number.Hexadecimal):
                 yield ttype, value
                 continue
 

--- a/sqlparse/formatter.py
+++ b/sqlparse/formatter.py
@@ -56,6 +56,11 @@ def validate_options(options):
         options['truncate_strings'] = truncate_strings
         options['truncate_char'] = options.get('truncate_char', '[...]')
 
+    truncate_values = options.get('truncate_values', False)
+    if truncate_values not in [True, False]:
+        raise SQLParseError('Invalid value for truncate_values: '
+                            '{!r}'.format(truncate_values))
+
     indent_columns = options.get('indent_columns', False)
     if indent_columns not in [True, False]:
         raise SQLParseError('Invalid value for indent_columns: '
@@ -148,6 +153,9 @@ def build_filter_stack(stack, options):
     if options.get('truncate_strings'):
         stack.preprocess.append(filters.TruncateStringFilter(
             width=options['truncate_strings'], char=options['truncate_char']))
+
+    if options.get('truncate_values', False):
+        stack.preprocess.append(filters.TruncateValueFilter())
 
     if options.get('use_space_around_operators', False):
         stack.enable_grouping()

--- a/tests/test_format.py
+++ b/tests/test_format.py
@@ -685,13 +685,14 @@ def test_truncate_strings_doesnt_truncate_identifiers(sql):
 def test_truncate_values():
     sql = "update foo set value = 123;"
     formatted = sqlparse.format(sql, truncate_values=True)
-    assert formatted == "update foo set value = 1.23;"
+    assert formatted == "update foo set value = ?;"
+    sql = "update foo set value = 1.23;"
     formatted = sqlparse.format(sql, truncate_values=True)
     assert formatted == "update foo set value = ?;"
-    assert formatted == "update foo set value = 0x100;"
+    sql = "update foo set value = 0x100;"
     formatted = sqlparse.format(sql, truncate_values=True)
     assert formatted == "update foo set value = ?;"
-    assert formatted == "update foo set value = 'xxx';"
+    sql = "update foo set value = 'xxx';"
     formatted = sqlparse.format(sql, truncate_values=True)
     assert formatted == "update foo set value = ?;"
 
@@ -699,7 +700,7 @@ def test_truncate_values():
 def test_truncate_values_invalid_option():
     sql = 'update foo set value = 123;'
     with pytest.raises(SQLParseError):
-        sqlparse.format(sql, strip_values=None)
+        sqlparse.format(sql, strip_values=2)
 
 
 def test_having_produces_newline():

--- a/tests/test_format.py
+++ b/tests/test_format.py
@@ -682,6 +682,26 @@ def test_truncate_strings_doesnt_truncate_identifiers(sql):
     assert formatted == sql
 
 
+def test_truncate_values():
+    sql = "update foo set value = 123;"
+    formatted = sqlparse.format(sql, truncate_values=True)
+    assert formatted == "update foo set value = 1.23;"
+    formatted = sqlparse.format(sql, truncate_values=True)
+    assert formatted == "update foo set value = ?;"
+    assert formatted == "update foo set value = 0x100;"
+    formatted = sqlparse.format(sql, truncate_values=True)
+    assert formatted == "update foo set value = ?;"
+    assert formatted == "update foo set value = 'xxx';"
+    formatted = sqlparse.format(sql, truncate_values=True)
+    assert formatted == "update foo set value = ?;"
+
+
+def test_truncate_values_invalid_option():
+    sql = 'update foo set value = 123;'
+    with pytest.raises(SQLParseError):
+        sqlparse.format(sql, strip_values=None)
+
+
 def test_having_produces_newline():
     sql = ('select * from foo, bar where bar.id = foo.bar_id '
            'having sum(bar.value) > 100')

--- a/tests/test_format.py
+++ b/tests/test_format.py
@@ -700,7 +700,7 @@ def test_truncate_values():
 def test_truncate_values_invalid_option():
     sql = 'update foo set value = 123;'
     with pytest.raises(SQLParseError):
-        sqlparse.format(sql, strip_values=2)
+        sqlparse.format(sql, truncate_values=None)
 
 
 def test_having_produces_newline():


### PR DESCRIPTION
sqlparse formatter can replace string values in a sql text with specified character and length by using truncate_strings option. However, we want to get a sql text  completely de-parameterized in some special situations, just like we use some placeholders to replace all values in a sql.  Here I add a new filter named TruncateValueFilter to implement this function.
F
or example:
sql = "select * from t1 where c1 = 123"
plain_sql = sqlparse.format(sql, truncate_values=True)
print (plain_sql)

We can get " select * from t1 where c1 = ?"