### PR TITLE
Add ClickHouse support

### DIFF
--- a/sqlparse/engine/grouping.py
+++ b/sqlparse/engine/grouping.py
@@ -317,6 +317,23 @@ def group_where(tlist):
         tidx, token = tlist.token_next_by(m=sql.Where.M_OPEN, idx=tidx)
 
 
+@recurse(sql.Prewhere)
+def group_prewhere(tlist):
+    tidx, token = tlist.token_next_by(m=sql.Prewhere.M_OPEN)
+    while token:
+        eidx, end = tlist.token_next_by(m=sql.Prewhere.M_CLOSE, idx=tidx)
+
+        if end is None:
+            end = tlist._groupable_tokens[-1]
+        else:
+            end = tlist.tokens[eidx - 1]
+        # TODO: convert this to eidx instead of end token.
+        # i think above values are len(tlist) and eidx-1
+        eidx = tlist.token_index(end)
+        tlist.group_tokens(sql.Prewhere, tidx, eidx)
+        tidx, token = tlist.token_next_by(m=sql.Prewhere.M_OPEN, idx=tidx)
+
+
 @recurse()
 def group_aliased(tlist):
     I_ALIAS = (sql.Parenthesis, sql.Function, sql.Case, sql.Identifier,
@@ -397,6 +414,7 @@ def group(stmt):
         group_begin,
 
         group_functions,
+        group_prewhere,
         group_where,
         group_period,
         group_arrays,

--- a/sqlparse/filters/aligned_indent.py
+++ b/sqlparse/filters/aligned_indent.py
@@ -12,11 +12,11 @@ from sqlparse.utils import offset, indent
 class AlignedIndentFilter:
     join_words = (r'((LEFT\s+|RIGHT\s+|FULL\s+)?'
                   r'(INNER\s+|OUTER\s+|STRAIGHT\s+)?|'
-                  r'(CROSS\s+|NATURAL\s+)?)?JOIN\b')
+                  r'(CROSS\s+|ARRAY\s+|NATURAL\s+)?)?JOIN\b')
     by_words = r'(GROUP|ORDER)\s+BY\b'
     split_words = ('FROM',
                    join_words, 'ON', by_words,
-                   'WHERE', 'AND', 'OR',
+                   'PREWHERE', 'WHERE', 'AND', 'OR',
                    'HAVING', 'LIMIT',
                    'UNION', 'VALUES',
                    'SET', 'BETWEEN', 'EXCEPT')

--- a/sqlparse/filters/reindent.py
+++ b/sqlparse/filters/reindent.py
@@ -100,6 +100,15 @@ class ReindentFilter:
         func = getattr(self, func_name.lower(), self._process_default)
         func(tlist)
 
+    def _process_prewhere(self, tlist):
+        tidx, token = tlist.token_next_by(m=(T.Keyword, 'PREWHERE'))
+        if not token:
+            return
+        # issue121, errors in statement fixed??
+        tlist.insert_before(tidx, self.nl())
+        with indent(self):
+            self._process_default(tlist)
+
     def _process_where(self, tlist):
         tidx, token = tlist.token_next_by(m=(T.Keyword, 'WHERE'))
         if not token:

--- a/sqlparse/keywords.py
+++ b/sqlparse/keywords.py
@@ -16,6 +16,7 @@ def is_keyword(value):
             or KEYWORDS_ORACLE.get(val)
             or KEYWORDS_PLPGSQL.get(val)
             or KEYWORDS_HQL.get(val)
+            or KEYWORDS_CLICKHOUSE.get(val)
             or KEYWORDS.get(val, tokens.Name)), value
 
 
@@ -75,7 +76,7 @@ SQL_REGEX = {
         # otherwise it's probably an array index
         (r'(?<![\w\])])(\[[^\]\[]+\])', tokens.Name),
         (r'((LEFT\s+|RIGHT\s+|FULL\s+)?(INNER\s+|OUTER\s+|STRAIGHT\s+)?'
-         r'|(CROSS\s+|NATURAL\s+)?)?JOIN\b', tokens.Keyword),
+         r'|(CROSS\s+|NATURAL\s+|ARRAY\s+)?)?JOIN\b', tokens.Keyword),
         (r'END(\s+IF|\s+LOOP|\s+WHILE)?\b', tokens.Keyword),
         (r'NOT\s+NULL\b', tokens.Keyword),
         (r'NULLS\s+(FIRST|LAST)\b', tokens.Keyword),
@@ -955,4 +956,11 @@ KEYWORDS_HQL = {
     'EXIT': tokens.Keyword,
     'BREAK': tokens.Keyword,
     'LEAVE': tokens.Keyword,
+}
+
+KEYWORDS_CLICKHOUSE = {
+    'FORMAT': tokens.Keyword,
+    'PREWHERE': tokens.Keyword,
+    'OPTIMIZE': tokens.Keyword,
+    'MATERIALIZED': tokens.Keyword,
 }

--- a/sqlparse/sql.py
+++ b/sqlparse/sql.py
@@ -549,8 +549,8 @@ class Prewhere(TokenList):
     """A PREWHERE clause."""
     M_OPEN = T.Keyword, 'PREWHERE'
     M_CLOSE = T.Keyword, (
-        'WHERE', 'ORDER BY', 'GROUP BY', 'LIMIT', 'UNION', 'UNION ALL', 'EXCEPT',
-        'HAVING', 'RETURNING', 'INTO')
+        'ORDER BY', 'GROUP BY', 'LIMIT', 'UNION', 'UNION ALL', 'EXCEPT',
+        'WHERE', 'HAVING', 'RETURNING', 'INTO')
 
 
 class Where(TokenList):

--- a/sqlparse/sql.py
+++ b/sqlparse/sql.py
@@ -545,6 +545,14 @@ class Comment(TokenList):
         return self.tokens and self.tokens[0].ttype == T.Comment.Multiline
 
 
+class Prewhere(TokenList):
+    """A PREWHERE clause."""
+    M_OPEN = T.Keyword, 'PREWHERE'
+    M_CLOSE = T.Keyword, (
+        'WHERE', 'ORDER BY', 'GROUP BY', 'LIMIT', 'UNION', 'UNION ALL', 'EXCEPT',
+        'HAVING', 'RETURNING', 'INTO')
+
+
 class Where(TokenList):
     """A WHERE clause."""
     M_OPEN = T.Keyword, 'WHERE'


### PR DESCRIPTION
[ClickHouse](https://clickhouse.tech/) is an OLAP database with some additional syntax

Were is an example of a query that uses most of the additional syntax
```sql
CREATE TABLE arrays_test
(
    s String,
    arr Array(UInt8)
) 
ENGINE = MergeTree() 
ORDER BY s 
PARTITION BY tuple();

INSERT INTO arrays_test VALUES ('Hello', [1,2]), ('World', [3,4,5]), ('Goodbye', []);

SELECT s, arr
FROM arrays_test
ARRAY JOIN arr
PREWHERE s='Hello'
WHERE arr>1
LIMIT 1 BY s
LIMIT 10
FORMAT Pretty;

Result
s    |arr|
-----|---|
Hello|  2|
```

```python
query="SELECT s, arr FROM arrays_test ARRAY JOIN arr PREWHERE s='Hello' WHERE arr>1 LIMIT 1 BY s LIMIT 10 FORMAT Pretty;"
print(sqlparse.format(query, reindent=True, keyword_case='upper'))

SELECT s,
       arr
FROM arrays_test
ARRAY JOIN arr
PREWHERE s='Hello'
WHERE arr>1
LIMIT 1 BY s
LIMIT 10
FORMAT Pretty;
```

Please refuse the pull request if you think it is a very specific database