### PR TITLE
Avoid tokens copy

### DIFF
--- a/sqlparse/sql.py
+++ b/sqlparse/sql.py
@@ -234,19 +234,16 @@ class TokenList(Token):
 
         if reverse:
             assert end is None
-            for idx in range(start - 2, -1, -1):
-                token = self.tokens[idx]
-                for func in funcs:
-                    if func(token):
-                        return idx, token
+            indexes = range(start - 2, -1, -1)
         else:
             if end is None:
                 end = len(self.tokens)
-            for idx in range(start, end):
-                token = self.tokens[idx]
-                for func in funcs:
-                    if func(token):
-                        return idx, token
+            indexes = range(start, end)
+        for idx in indexes:
+            token = self.tokens[idx]
+            for func in funcs:
+                if func(token):
+                    return idx, token
         return None, None
 
     def token_first(self, skip_ws=True, skip_cm=False):

--- a/sqlparse/sql.py
+++ b/sqlparse/sql.py
@@ -240,7 +240,10 @@ class TokenList(Token):
                     if func(token):
                         return idx, token
         else:
-            for idx, token in enumerate(self.tokens[start:end], start=start):
+            if end is None:
+                end = len(self.tokens)
+            for idx in range(start, end):
+                token = self.tokens[idx]
                 for func in funcs:
                     if func(token):
                         return idx, token


### PR DESCRIPTION
Partial fix for #621:

In `TokenList._token_matching()` avoid quadratic behavior resulting from taking a slice of `self.tokens` during each invocation.  Since we are working with indexes anyway, just generate the indexes using `range()` and use normal indexing to access the desired tokens instead of calling `enumerate()` with a slice from `self.tokens`.