### PR TITLE
Compute TokenList.value dynamically

### DIFF
--- a/sqlparse/__init__.py
+++ b/sqlparse/__init__.py
@@ -38,6 +38,7 @@ def parsestream(stream, encoding=None):
     :returns: A generator of :class:`~sqlparse.sql.Statement` instances.
     """
     stack = engine.FilterStack()
+    stack.stmtprocess.append(stack.grouping_filter)
     stack.enable_grouping()
     return stack.run(stream, encoding)
 

--- a/sqlparse/engine/filter_stack.py
+++ b/sqlparse/engine/filter_stack.py
@@ -7,8 +7,8 @@
 
 """filter"""
 
+from sqlparse import filters
 from sqlparse import lexer
-from sqlparse.engine import grouping
 from sqlparse.engine.statement_splitter import StatementSplitter
 
 
@@ -17,10 +17,10 @@ class FilterStack:
         self.preprocess = []
         self.stmtprocess = []
         self.postprocess = []
-        self._grouping = False
+        self.grouping_filter = filters.GroupingFilter()
 
     def enable_grouping(self):
-        self._grouping = True
+        self.grouping_filter.enable()
 
     def run(self, sql, encoding=None):
         stream = lexer.tokenize(sql, encoding)
@@ -32,9 +32,6 @@ class FilterStack:
 
         # Output: Stream processed Statements
         for stmt in stream:
-            if self._grouping:
-                stmt = grouping.group(stmt)
-
             for filter_ in self.stmtprocess:
                 filter_.process(stmt)
 

--- a/sqlparse/filters/__init__.py
+++ b/sqlparse/filters/__init__.py
@@ -5,6 +5,7 @@
 # This module is part of python-sqlparse and is released under
 # the BSD License: https://opensource.org/licenses/BSD-3-Clause
 
+from sqlparse.filters.others import GroupingFilter
 from sqlparse.filters.others import SerializerUnicode
 from sqlparse.filters.others import StripCommentsFilter
 from sqlparse.filters.others import StripWhitespaceFilter
@@ -22,6 +23,7 @@ from sqlparse.filters.right_margin import RightMarginFilter
 from sqlparse.filters.aligned_indent import AlignedIndentFilter
 
 __all__ = [
+    'GroupingFilter',
     'SerializerUnicode',
     'StripCommentsFilter',
     'StripWhitespaceFilter',

--- a/sqlparse/filters/others.py
+++ b/sqlparse/filters/others.py
@@ -8,7 +8,22 @@
 import re
 
 from sqlparse import sql, tokens as T
+from sqlparse.engine import grouping
 from sqlparse.utils import split_unquoted_newlines
+
+
+class GroupingFilter:
+    def __init__(self):
+        self._enabled = False
+
+    def enable(self):
+        self._enabled = True
+
+    def process(self, stmt):
+        if self._enabled:
+            return grouping.group(stmt)
+        else:
+            return stmt
 
 
 class StripCommentsFilter:

--- a/sqlparse/filters/others.py
+++ b/sqlparse/filters/others.py
@@ -63,7 +63,7 @@ class StripCommentsFilter:
             tidx, token = get_next_comment()
 
     def process(self, stmt):
-        [self.process(sgroup) for sgroup in stmt.get_sublists()]
+        grouping.group_comments(stmt)
         StripCommentsFilter._process(stmt)
         return stmt
 

--- a/sqlparse/filters/others.py
+++ b/sqlparse/filters/others.py
@@ -27,12 +27,11 @@ class GroupingFilter:
 
 
 class StripCommentsFilter:
-
     @staticmethod
-    def _process(tlist):
+    def process(stmt):
         def get_next_comment():
             # TODO(andi) Comment types should be unified, see related issue38
-            return tlist.token_next_by(i=sql.Comment, t=T.Comment)
+            return stmt.token_next_by(i=sql.Comment, t=T.Comment)
 
         def _get_insert_token(token):
             """Returns either a whitespace or the line breaks from token."""
@@ -43,10 +42,12 @@ class StripCommentsFilter:
             else:
                 return sql.Token(T.Whitespace, ' ')
 
+        grouping.group_comments(stmt)
+
         tidx, token = get_next_comment()
         while token:
-            pidx, prev_ = tlist.token_prev(tidx, skip_ws=False)
-            nidx, next_ = tlist.token_next(tidx, skip_ws=False)
+            pidx, prev_ = stmt.token_prev(tidx, skip_ws=False)
+            nidx, next_ = stmt.token_next(tidx, skip_ws=False)
             # Replace by whitespace if prev and next exist and if they're not
             # whitespaces. This doesn't apply if prev or next is a parenthesis.
             if (prev_ is None or next_ is None
@@ -55,16 +56,13 @@ class StripCommentsFilter:
                 # Insert a whitespace to ensure the following SQL produces
                 # a valid SQL (see #425).
                 if prev_ is not None and not prev_.match(T.Punctuation, '('):
-                    tlist.tokens.insert(tidx, _get_insert_token(token))
-                tlist.tokens.remove(token)
+                    stmt.tokens.insert(tidx, _get_insert_token(token))
+                stmt.tokens.remove(token)
             else:
-                tlist.tokens[tidx] = _get_insert_token(token)
+                stmt.tokens[tidx] = _get_insert_token(token)
 
             tidx, token = get_next_comment()
 
-    def process(self, stmt):
-        grouping.group_comments(stmt)
-        StripCommentsFilter._process(stmt)
         return stmt
 
 

--- a/sqlparse/formatter.py
+++ b/sqlparse/formatter.py
@@ -149,6 +149,10 @@ def build_filter_stack(stack, options):
         stack.preprocess.append(filters.TruncateStringFilter(
             width=options['truncate_strings'], char=options['truncate_char']))
 
+    # Before grouping
+    if options.get('strip_comments'):
+        stack.stmtprocess.append(filters.StripCommentsFilter())
+
     # Grouping
     stack.stmtprocess.append(stack.grouping_filter)
 
@@ -156,10 +160,6 @@ def build_filter_stack(stack, options):
     if options.get('use_space_around_operators', False):
         stack.enable_grouping()
         stack.stmtprocess.append(filters.SpacesAroundOperatorsFilter())
-
-    if options.get('strip_comments'):
-        stack.enable_grouping()
-        stack.stmtprocess.append(filters.StripCommentsFilter())
 
     if options.get('strip_whitespace') or options.get('reindent'):
         stack.enable_grouping()

--- a/sqlparse/formatter.py
+++ b/sqlparse/formatter.py
@@ -149,11 +149,14 @@ def build_filter_stack(stack, options):
         stack.preprocess.append(filters.TruncateStringFilter(
             width=options['truncate_strings'], char=options['truncate_char']))
 
+    # Grouping
+    stack.stmtprocess.append(stack.grouping_filter)
+
+    # After grouping
     if options.get('use_space_around_operators', False):
         stack.enable_grouping()
         stack.stmtprocess.append(filters.SpacesAroundOperatorsFilter())
 
-    # After grouping
     if options.get('strip_comments'):
         stack.enable_grouping()
         stack.stmtprocess.append(filters.StripCommentsFilter())

--- a/sqlparse/sql.py
+++ b/sqlparse/sql.py
@@ -45,6 +45,9 @@ class TokenBase:
     def __init__(self):
         self.parent = None
 
+    def __str__(self):
+        return self.value
+
     # Pending tokenlist __len__ bug fix
     # def __len__(self):
     #     return len(self.value)
@@ -144,9 +147,6 @@ class Token(TokenBase):
         self.is_whitespace = ttype in T.Whitespace
         self.normalized = value.upper() if self.is_keyword else value
 
-    def __str__(self):
-        return self.value
-
     def _get_repr_name(self):
         return str(self.ttype).split('.')[-1]
 
@@ -158,12 +158,11 @@ class Token(TokenBase):
 class TokenList(TokenBase):
     """A group of tokens.
 
-    It has two instance attributes:
-    ``value`` is the unchanged value of the token and ``tokens`` is a list of
+    It has one instance attribute ``tokens`` which holds a list of
     child-tokens.
     """
 
-    __slots__ = ('tokens', 'value')
+    __slots__ = 'tokens'
 
     is_group = True
     ttype = None
@@ -173,10 +172,10 @@ class TokenList(TokenBase):
     def __init__(self, tokens=None):
         super().__init__()
         self.tokens = tokens or []
-        self.value = str(self)
         [setattr(token, 'parent', self) for token in self.tokens]
 
-    def __str__(self):
+    @property
+    def value(self):
         return ''.join(token.value for token in self.flatten())
 
     @property
@@ -341,7 +340,6 @@ class TokenList(TokenBase):
             grp = start
             grp.tokens.extend(subtokens)
             del self.tokens[start_idx + 1:end_idx]
-            grp.value = str(start)
         else:
             subtokens = self.tokens[start_idx:end_idx]
             grp = grp_cls(subtokens)


### PR DESCRIPTION
Partial fix for #621:

To avoid quadratic behavior, make `TokenList.value` a dynamically-computed property rather than an attribute so that it does not need to be recomputed each time `TokenList.group_tokens()` is called with `extend=True`.

The first three commits in this PR are supporting work:  I found that making `TokenList.value` a property caused test failures due to line endings not being correctly preserved when stripping comments.  This is due to the fact that before making `TokenList.value` a property, the `StripCommentsFilter` was changing the underlying tokens without updating the `value` attribute of the parent `TokenList`.   After making `TokenList.value` a property, those changes did get reflected in the parent `TokenList`'s `value` and as a result the desired line endings were being lost.

The most straightforward way I found to address this was to make comment stripping happen before grouping is performed, which required a small amount of hackery to make grouping happen via a filter.  I am open to suggestions to better ways to handle this.

I am also a little concerned about the possibility for slowdowns if a particular `TokenList`'s value is accessed, and thus computed, multiple times, but I didn't actually observe any.  This might still be an issue via a codepath I didn't look at.  I have some ideas on how to address it if a performance problem comes up, but it would clutter up the code somewhat so I didn't want to implement it unless a need could be demonstrated.