### PR TITLE
Add backtick to remove_quotes character list

### DIFF
--- a/sqlparse/utils.py
+++ b/sqlparse/utils.py
@@ -55,7 +55,7 @@ def remove_quotes(val):
     """Helper that removes surrounding quotes from strings."""
     if val is None:
         return
-    if val[0] in ('"', "'") and val[0] == val[-1]:
+    if val[0] in ('"', "'", '`') and val[0] == val[-1]:
         val = val[1:-1]
     return val
 


### PR DESCRIPTION
Fix #628 
Consider backtick `` ` ``as a quote character and remove it in utils.removte_quotes()