### PR TITLE
Fixed bad parsing of create table statements that use lower case

### DIFF
--- a/sqlparse/engine/grouping.py
+++ b/sqlparse/engine/grouping.py
@@ -335,9 +335,9 @@ def group_functions(tlist):
     has_create = False
     has_table = False
     for tmp_token in tlist.tokens:
-        if tmp_token.value == 'CREATE':
+        if tmp_token.value.upper() == 'CREATE':
             has_create = True
-        if tmp_token.value == 'TABLE':
+        if tmp_token.value.upper() == 'TABLE':
             has_table = True
     if has_create and has_table:
         return

--- a/tests/test_grouping.py
+++ b/tests/test_grouping.py
@@ -655,3 +655,7 @@ def test_grouping_as_cte():
     assert p[0].get_alias() is None
     assert p[2].value == 'AS'
     assert p[4].value == 'WITH'
+
+def test_grouping_create_table():
+    p = sqlparse.parse("create table db.tbl (a string)")[0].tokens
+    assert p[4].value == "db.tbl"


### PR DESCRIPTION
there were missing `upper()` calls that messed up parsing of some of my create table statements.
Try running the new test without and with my contribution and you will see the bad behavior.

Best,

Simon