### PR TITLE
CREATE TABLE tbl AS SELECT should return get_alias() for its column

### DIFF
--- a/sqlparse/engine/grouping.py
+++ b/sqlparse/engine/grouping.py
@@ -334,12 +334,15 @@ def group_aliased(tlist):
 def group_functions(tlist):
     has_create = False
     has_table = False
+    has_as = False
     for tmp_token in tlist.tokens:
         if tmp_token.value == 'CREATE':
             has_create = True
         if tmp_token.value == 'TABLE':
             has_table = True
-    if has_create and has_table:
+        if tmp_token.value == 'AS':
+            has_as = True
+    if has_create and has_table and not has_as:
         return
 
     tidx, token = tlist.token_next_by(t=T.Name)

--- a/tests/test_grouping.py
+++ b/tests/test_grouping.py
@@ -324,6 +324,11 @@ def test_grouping_alias_case():
     assert p.tokens[0].get_alias() == 'foo'
 
 
+def test_grouping_alias_ctas():
+    p = sqlparse.parse('CREATE TABLE tbl1 AS SELECT coalesce(t1.col1, 0) AS col1 FROM t1')[0]
+    assert p.tokens[10].get_alias() == 'col1'
+    assert isinstance(p.tokens[10].tokens[0], sql.Function)
+
 def test_grouping_subquery_no_parens():
     # Not totally sure if this is the right approach...
     # When a THEN clause contains a subquery w/o parenthesis around it *and*


### PR DESCRIPTION
Currently, CREATE TABLE AS SELECT a.k.a. CTAS doesn't parse column aliases with functions e.g., coalesce, if, appropriately.

In the following example, `coalesce` is parsed as `Name` while it should be `Function` to get `get_alias()` appropriately.

## Before

```py
>>> import sqlparse
>>> p = sqlparse.parse('CREATE TABLE tbl1 AS SELECT coalesce(t1.col1, 0) AS col1 FROM t1')[0]
>>> p._pprint_tree()
|- 0 DDL 'CREATE'
|- 1 Whitespace ' '
|- 2 Keyword 'TABLE'
|- 3 Whitespace ' '
|- 4 Identifier 'tbl1'
|  `- 0 Name 'tbl1'
|- 5 Whitespace ' '
|- 6 Keyword 'AS'
|- 7 Whitespace ' '
|- 8 DML 'SELECT'
|- 9 Whitespace ' '
|- 10 Identifier 'coales...'
|  |- 0 Name 'coales...'
|  `- 1 Identifier '(t1.co...'
|     |- 0 Parenthesis '(t1.co...'
|     |  |- 0 Punctuation '('
|     |  |- 1 IdentifierList 't1.col...'
|     |  |  |- 0 Identifier 't1.col1'
|     |  |  |  |- 0 Name 't1'
|     |  |  |  |- 1 Punctuation '.'
|     |  |  |  `- 2 Name 'col1'
|     |  |  |- 1 Punctuation ','
|     |  |  |- 2 Whitespace ' '
|     |  |  `- 3 Integer '0'
|     |  `- 2 Punctuation ')'
|     |- 1 Whitespace ' '
|     |- 2 Keyword 'AS'
|     |- 3 Whitespace ' '
|     `- 4 Identifier 'col1'
|        `- 0 Name 'col1'
|- 11 Whitespace ' '
|- 12 Keyword 'FROM'
|- 13 Whitespace ' '
`- 14 Identifier 't1'
   `- 0 Name 't1'
>>> p.tokens[10].get_alias()
# Should return 'col1'
```

## After

```py
>>> p = sqlparse.parse('CREATE TABLE tbl1 AS SELECT coalesce(t1.col1, 0) AS col1 FROM t1')[0]
>>> p._pprint_tree()
|- 0 DDL 'CREATE'
|- 1 Whitespace ' '
|- 2 Keyword 'TABLE'
|- 3 Whitespace ' '
|- 4 Identifier 'tbl1'
|  `- 0 Name 'tbl1'
|- 5 Whitespace ' '
|- 6 Keyword 'AS'
|- 7 Whitespace ' '
|- 8 DML 'SELECT'
|- 9 Whitespace ' '
|- 10 Identifier 'coales...'
|  |- 0 Function 'coales...'
|  |  |- 0 Identifier 'coales...'
|  |  |  `- 0 Name 'coales...'
|  |  `- 1 Parenthesis '(t1.co...'
|  |     |- 0 Punctuation '('
|  |     |- 1 IdentifierList 't1.col...'
|  |     |  |- 0 Identifier 't1.col1'
|  |     |  |  |- 0 Name 't1'
|  |     |  |  |- 1 Punctuation '.'
|  |     |  |  `- 2 Name 'col1'
|  |     |  |- 1 Punctuation ','
|  |     |  |- 2 Whitespace ' '
|  |     |  `- 3 Integer '0'
|  |     `- 2 Punctuation ')'
|  |- 1 Whitespace ' '
|  |- 2 Keyword 'AS'
|  |- 3 Whitespace ' '
|  `- 4 Identifier 'col1'
|     `- 0 Name 'col1'
|- 11 Whitespace ' '
|- 12 Keyword 'FROM'
|- 13 Whitespace ' '
`- 14 Identifier 't1'
   `- 0 Name 't1'
>>> p.tokens[10].get_alias()
'col1'
```