### PR TITLE
adding Spark keywords

### DIFF
--- a/sqlparse/keywords.py
+++ b/sqlparse/keywords.py
@@ -22,6 +22,7 @@ def is_keyword(value):
             or KEYWORDS_PLPGSQL.get(val)
             or KEYWORDS_HQL.get(val)
             or KEYWORDS_MSACCESS.get(val)
+            or KEYWORDS_SPARK.get(val)
             or KEYWORDS.get(val, tokens.Name)), value
 
 
@@ -974,4 +975,21 @@ KEYWORDS_HQL = {
 
 KEYWORDS_MSACCESS = {
     'DISTINCTROW': tokens.Keyword,
+}
+
+
+# SPARK Syntax
+# see https://spark.apache.org/docs/latest/sql-ref-syntax.html
+KEYWORDS_SPARK ={
+    'BUCKETS': tokens.Keyword,
+    'CLUSTERED': tokens.Keyword,
+    'CSV': tokens.Keyword,
+    'DBPROPERTIES': tokens.Keyword,
+    'DELTA': tokens.Keyword,
+    'JDBC': tokens.Keyword,
+    'ORC': tokens.Keyword,
+    'PARQUET': tokens.Keyword,
+    'PARTITIONED': tokens.Keyword,
+    'SORTED': tokens.Keyword,
+    'TXT': tokens.Keyword,
 }

--- a/sqlparse/keywords.py
+++ b/sqlparse/keywords.py
@@ -980,16 +980,16 @@ KEYWORDS_MSACCESS = {
 
 # SPARK Syntax
 # see https://spark.apache.org/docs/latest/sql-ref-syntax.html
-KEYWORDS_SPARK ={
-    'BUCKETS': tokens.Keyword,
-    'CLUSTERED': tokens.Keyword,
-    'CSV': tokens.Keyword,
-    'DBPROPERTIES': tokens.Keyword,
-    'DELTA': tokens.Keyword,
-    'JDBC': tokens.Keyword,
-    'ORC': tokens.Keyword,
-    'PARQUET': tokens.Keyword,
-    'PARTITIONED': tokens.Keyword,
-    'SORTED': tokens.Keyword,
-    'TXT': tokens.Keyword,
+KEYWORDS_SPARK = {
+    "BUCKETS": tokens.Keyword,
+    "CLUSTERED": tokens.Keyword,
+    "CSV": tokens.Keyword,
+    "DBPROPERTIES": tokens.Keyword,
+    "DELTA": tokens.Keyword,
+    "JDBC": tokens.Keyword,
+    "ORC": tokens.Keyword,
+    "PARQUET": tokens.Keyword,
+    "PARTITIONED": tokens.Keyword,
+    "SORTED": tokens.Keyword,
+    "TXT": tokens.Keyword,
 }

--- a/tests/test_keywords.py
+++ b/tests/test_keywords.py
@@ -1,5 +1,6 @@
 import pytest
 
+import sqlparse
 from sqlparse import tokens
 from sqlparse.keywords import SQL_REGEX
 
@@ -11,3 +12,50 @@ class TestSQLREGEX:
     def test_float_numbers(self, number):
         ttype = next(tt for action, tt in SQL_REGEX if action(number))
         assert tokens.Number.Float == ttype
+
+    def test_spark_keywords(self):
+        statements = sqlparse.parse(
+            """
+            CREATE DATABASE IF NOT EXISTS database_name
+            COMMENT "my database comment"
+            LOCATION "/mnt/path/to/db"
+            WITH DBPROPERTIES (property_name=property_value) ;
+
+            CREATE TABLE IF NOT EXISTS database_name.table_identifier
+            (
+                col_name1 int COMMENT "woah, cool column",
+                b string
+            )
+            USING DELTA
+            OPTIONS ( key1=val1, key2=val2 )
+            PARTITIONED BY ( col_name1  )
+            CLUSTERED BY ( b )
+            SORTED BY ( col_name1  DESC )
+            INTO 4 BUCKETS
+            LOCATION "/mnt/path/to/db/tbl"
+            COMMENT "nice table"
+            TBLPROPERTIES ( key1=val1, key2=val2  )
+        """
+        )
+
+        db_tokens = list(
+            filter(lambda t: str(t.ttype).find("Whitespace") < 0, statements[0].tokens)
+        )
+
+        # DBPROPERTIES
+        assert db_tokens[11].ttype == tokens.Keyword
+
+        tbl_tokens = list(
+            filter(lambda t: str(t.ttype).find("Whitespace") < 0, statements[1].tokens)
+        )
+        position = {
+            7: "USING",
+            8: "DELTA",
+            11: "PARTITIONED",
+            14: "CLUSTERED",
+            17: "SORTED",
+            22: "BUCKETS",
+        }
+        for pos, val in position.items():
+            assert tbl_tokens[pos].ttype == tokens.Keyword
+            assert tbl_tokens[pos].value == val


### PR DESCRIPTION
I would like to use this library to parse Spark SQL. Especially I am trying to parse databricks CREATE TABLE and CREATE DATABASE statements.
https://spark.apache.org/docs/latest/sql-ref-syntax-ddl-create-table-datasource.html
https://spark.apache.org/docs/3.0.0-preview/sql-ref-syntax-ddl-create-database.html
These statements contain some further keywords than the ones already in the library.
I created a new section of SPARK_KEYWORDS in the keywords.py file.

Maybe it would also be nice to have an extension mechanism in the library where a user can quickly extend the keyword range without a PR like this. If you like this idea, I will make another PR for it.