### PR TITLE
Configurable syntax

### DIFF
--- a/docs/source/extending.rst
+++ b/docs/source/extending.rst
@@ -44,7 +44,12 @@ a keyword to the lexer:
     from sqlparse import keywords
     from sqlparse.lexer import Lexer
 
+    # get the lexer singleton object to configure it
     lex = Lexer()
+
+    # Clear the default configurations.
+    # After this call, reg-exps and keyword dictionaries need to be loaded
+    # to make the lexer functional again.
     lex.clear()
 
     my_regex = (r"ZORDER\s+BY\b", sqlparse.tokens.Keyword)
@@ -55,12 +60,17 @@ a keyword to the lexer:
         + [my_regex]
         + keywords.SQL_REGEX[38:]
     )
+
+    # add the default keyword dictionaries
     lex.add_keywords(keywords.KEYWORDS_COMMON)
     lex.add_keywords(keywords.KEYWORDS_ORACLE)
     lex.add_keywords(keywords.KEYWORDS_PLPGSQL)
     lex.add_keywords(keywords.KEYWORDS_HQL)
     lex.add_keywords(keywords.KEYWORDS_MSACCESS)
     lex.add_keywords(keywords.KEYWORDS)
+
+    # add a custom keyword dictionary
     lex.add_keywords({'BAR', sqlparse.tokens.Keyword})
 
+    # no configuration is passed here. The lexer is used as a singleton.
     sqlparse.parse("select * from foo zorder by bar;")

--- a/docs/source/extending.rst
+++ b/docs/source/extending.rst
@@ -45,7 +45,7 @@ a keyword to the lexer:
     from sqlparse.lexer import Lexer
 
     # get the lexer singleton object to configure it
-    lex = Lexer()
+    lex = Lexer.get_default_instance()
 
     # Clear the default configurations.
     # After this call, reg-exps and keyword dictionaries need to be loaded

--- a/docs/source/extending.rst
+++ b/docs/source/extending.rst
@@ -1,0 +1,66 @@
+Extending :mod:`sqlparse`
+=========================
+
+.. module:: sqlparse
+   :synopsis: Extending parsing capability of sqlparse.
+
+The :mod:`sqlparse` module uses a sql grammar that was tuned through usage and numerous
+PR to fit a broad range of SQL syntaxes, but it cannot cater to every given case since
+some SQL dialects have adopted conflicting meanings of certain keywords. Sqlparse
+therefore exposes a mechanism to configure the fundamental keywords and regular
+expressions that parse the language as described below.
+
+If you find an adaptation that works for your specific use-case. Please consider
+contributing it back to the community by opening a PR on
+`GitHub <https://github.com/andialbrecht/sqlparse>`_.
+
+Configuring the Lexer
+---------------------
+
+The lexer is a singleton class that breaks down the stream of characters into language
+tokens. It does this by using a sequence of regular expressions and keywords that are
+listed in the file ``sqlparse.keywords``. Instead of applying these fixed grammar
+definitions directly, the lexer is default initialized in its method called
+``default_initialization()``. As an api user, you can adapt the Lexer configuration by
+applying your own configuration logic. To do so, start out by clearing previous
+configurations with ``.clear()``, then apply the SQL list with
+``.set_SQL_REGEX(SQL_REGEX)``, and apply keyword lists with ``.add_keywords(KEYWORDS)``.
+
+You can do so by re-using the expressions in ``sqlparse.keywords`` (see example below),
+leaving parts out, or by making up your own master list.
+
+See the expected types of the arguments by inspecting their structure in
+``sqlparse.keywords``.
+(For compatibility with python 3.4, this library does not use type-hints.)
+
+The following example adds support for the expression ``ZORDER BY``, and adds ``BAR`` as
+a keyword to the lexer:
+
+..  code-block:: python
+
+    import re
+
+    import sqlparse
+    from sqlparse import keywords
+    from sqlparse.lexer import Lexer
+
+    lex = Lexer()
+    lex.clear()
+
+    my_regex = (r"ZORDER\s+BY\b", sqlparse.tokens.Keyword)
+
+    # slice the default SQL_REGEX to inject the custom object
+    lex.set_SQL_REGEX(
+        keywords.SQL_REGEX[:38]
+        + [my_regex]
+        + keywords.SQL_REGEX[38:]
+    )
+    lex.add_keywords(keywords.KEYWORDS_COMMON)
+    lex.add_keywords(keywords.KEYWORDS_ORACLE)
+    lex.add_keywords(keywords.KEYWORDS_PLPGSQL)
+    lex.add_keywords(keywords.KEYWORDS_HQL)
+    lex.add_keywords(keywords.KEYWORDS_MSACCESS)
+    lex.add_keywords(keywords.KEYWORDS)
+    lex.add_keywords({'BAR', sqlparse.tokens.Keyword})
+
+    sqlparse.parse("select * from foo zorder by bar;")

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -20,6 +20,7 @@ Contents
    api
    analyzing
    ui
+   extending
    changes
    license
    indices

--- a/sqlparse/keywords.py
+++ b/sqlparse/keywords.py
@@ -6,23 +6,17 @@
 # the BSD License: https://opensource.org/licenses/BSD-3-Clause
 
 import re
+from typing import Dict, List, Tuple, Callable, Union
 
 from sqlparse import tokens
 
+# object() only supports "is" and is useful as a marker
+PROCESS_AS_KEYWORD = object()
 
-def is_keyword(value):
-    """Checks for a keyword.
-
-    If the given value is in one of the KEYWORDS_* dictionary
-    it's considered a keyword. Otherwise tokens.Name is returned.
-    """
-    val = value.upper()
-    return (KEYWORDS_COMMON.get(val)
-            or KEYWORDS_ORACLE.get(val)
-            or KEYWORDS_PLPGSQL.get(val)
-            or KEYWORDS_HQL.get(val)
-            or KEYWORDS_MSACCESS.get(val)
-            or KEYWORDS.get(val, tokens.Name)), value
+SQL_REGEX_TYPE = List[
+    Tuple[Callable, Union[type(PROCESS_AS_KEYWORD), tokens._TokenType]]
+]
+KEYWORDS_TYPE = Dict[str, tokens._TokenType]
 
 
 SQL_REGEX = {
@@ -99,7 +93,7 @@ SQL_REGEX = {
         (r'(NOT\s+)?(REGEXP)\b', tokens.Operator.Comparison),
         # Check for keywords, also returns tokens.Name if regex matches
         # but the match isn't a keyword.
-        (r'[0-9_\w][_$#\w]*', is_keyword),
+        (r'[0-9_\w][_$#\w]*', PROCESS_AS_KEYWORD),
         (r'[;:()\[\],\.]', tokens.Punctuation),
         (r'[<>=~!]+', tokens.Operator.Comparison),
         (r'[+/@#%^&|^-]+', tokens.Operator),

--- a/sqlparse/keywords.py
+++ b/sqlparse/keywords.py
@@ -6,17 +6,11 @@
 # the BSD License: https://opensource.org/licenses/BSD-3-Clause
 
 import re
-from typing import Dict, List, Tuple, Callable, Union
 
 from sqlparse import tokens
 
 # object() only supports "is" and is useful as a marker
 PROCESS_AS_KEYWORD = object()
-
-SQL_REGEX_TYPE = List[
-    Tuple[Callable, Union[type(PROCESS_AS_KEYWORD), tokens._TokenType]]
-]
-KEYWORDS_TYPE = Dict[str, tokens._TokenType]
 
 
 SQL_REGEX = {

--- a/sqlparse/lexer.py
+++ b/sqlparse/lexer.py
@@ -7,6 +7,7 @@
 
 """SQL Lexer"""
 import re
+
 # This code is based on the SqlLexer in pygments.
 # http://pygments.org/
 # It's separated from the rest of pygments to increase performance
@@ -18,20 +19,38 @@ from sqlparse import tokens, keywords
 from sqlparse.utils import consume
 
 
-class _LexerSingletonMetaclass(type):
-    _lexer_instance = None
-
-    def __call__(cls, *args, **kwargs):
-        if _LexerSingletonMetaclass._lexer_instance is None:
-            _LexerSingletonMetaclass._lexer_instance = super(
-                _LexerSingletonMetaclass, cls
-            ).__call__(*args, **kwargs)
-        return _LexerSingletonMetaclass._lexer_instance
-
-
-class Lexer(metaclass=_LexerSingletonMetaclass):
+class Lexer:
     """The Lexer supports configurable syntax.
     To add support for additional keywords, use the `add_keywords` method."""
+
+    _default_intance = None
+
+    # Development notes:
+    # - This class is prepared to be able to support additional SQL dialects
+    #   in the future by adding additional functions that take the place of
+    #   the function default_initialization()
+    # - The lexer class uses an explicit singleton behavior with the
+    #   instance-getter method get_default_instance(). This mechanism has
+    #   the advantage that the call signature of the entry-points to the
+    #   sqlparse library are not affected. Also, usage of sqlparse in third
+    #   party code does not need to be adapted. On the other hand, singleton
+    #   behavior is not thread safe, and the current implementation does not
+    #   easily allow for multiple SQL dialects to be parsed in the same
+    #   process. Such behavior can be supported in the future by passing a
+    #   suitably initialized lexer object as an additional parameter to the
+    #   entry-point functions (such as `parse`). Code will need to be written
+    #   to pass down and utilize such an object. The current implementation
+    #   is prepared to support this thread safe approach without the
+    #   default_instance part needing to change interface.
+
+    @classmethod
+    def get_default_instance(cls):
+        """Returns the lexer instance used internally
+        by the sqlparse core functions."""
+        if cls._default_intance is None:
+            cls._default_intance = cls()
+            cls._default_intance.default_initialization()
+        return cls._default_intance
 
     def default_initialization(self):
         """Initialize the lexer with default dictionaries.
@@ -45,13 +64,10 @@ class Lexer(metaclass=_LexerSingletonMetaclass):
         self.add_keywords(keywords.KEYWORDS_MSACCESS)
         self.add_keywords(keywords.KEYWORDS)
 
-    def __init__(self):
-        self.default_initialization()
-
     def clear(self):
         """Clear all syntax configurations.
         Useful if you want to load a reduced set of syntax configurations.
-        After this call, reg-exps and keyword dictionaries need to be loaded
+        After this call, regexps and keyword dictionaries need to be loaded
         to make the lexer functional again."""
         self._SQL_REGEX = []
         self._keywords = []
@@ -73,7 +89,7 @@ class Lexer(metaclass=_LexerSingletonMetaclass):
         """Checks for a keyword.
 
         If the given value is in one of the KEYWORDS_* dictionary
-        it's considered a keyword. Otherwise tokens.Name is returned.
+        it's considered a keyword. Otherwise, tokens.Name is returned.
         """
         val = value.upper()
         for kwdict in self._keywords:
@@ -136,4 +152,4 @@ def tokenize(sql, encoding=None):
     Tokenize *sql* using the :class:`Lexer` and return a 2-tuple stream
     of ``(token type, value)`` items.
     """
-    return Lexer().get_tokens(sql, encoding)
+    return Lexer.get_default_instance().get_tokens(sql, encoding)

--- a/sqlparse/lexer.py
+++ b/sqlparse/lexer.py
@@ -13,7 +13,6 @@
 # and to allow some customizations.
 
 from io import TextIOBase
-from typing import List
 
 from sqlparse import tokens, keywords
 from sqlparse.utils import consume
@@ -33,9 +32,6 @@ class _LexerSingletonMetaclass(type):
 class Lexer(metaclass=_LexerSingletonMetaclass):
     """The Lexer supports configurable syntax.
     To add support for additional keywords, use the `add_keywords` method."""
-
-    _SQL_REGEX: keywords.SQL_REGEX_TYPE
-    _keywords: List[keywords.KEYWORDS_TYPE]
 
     def default_initialization(self):
         """Initialize the lexer with default dictionaries.
@@ -58,11 +54,11 @@ class Lexer(metaclass=_LexerSingletonMetaclass):
         self._SQL_REGEX = []
         self._keywords = []
 
-    def set_SQL_REGEX(self, SQL_REGEX: keywords.SQL_REGEX_TYPE):
+    def set_SQL_REGEX(self, SQL_REGEX):
         """Set the list of regex that will parse the SQL."""
         self._SQL_REGEX = SQL_REGEX
 
-    def add_keywords(self, keywords: keywords.KEYWORDS_TYPE):
+    def add_keywords(self, keywords):
         """Add keyword dictionaries. Keywords are looked up in the same order
         that dictionaries were added."""
         self._keywords.append(keywords)

--- a/sqlparse/lexer.py
+++ b/sqlparse/lexer.py
@@ -57,7 +57,10 @@ class Lexer(metaclass=_LexerSingletonMetaclass):
     def set_SQL_REGEX(self, SQL_REGEX):
         """Set the list of regex that will parse the SQL."""
         FLAGS = re.IGNORECASE | re.UNICODE
-        self._SQL_REGEX = [(re.compile(rx, FLAGS).match, tt) for rx, tt in SQL_REGEX]
+        self._SQL_REGEX = [
+            (re.compile(rx, FLAGS).match, tt)
+            for rx, tt in SQL_REGEX
+        ]
 
     def add_keywords(self, keywords):
         """Add keyword dictionaries. Keywords are looked up in the same order

--- a/sqlparse/lexer.py
+++ b/sqlparse/lexer.py
@@ -50,7 +50,9 @@ class Lexer(metaclass=_LexerSingletonMetaclass):
 
     def clear(self):
         """Clear all syntax configurations.
-        Useful if you want to load a reduced set of syntax configurations."""
+        Useful if you want to load a reduced set of syntax configurations.
+        After this call, reg-exps and keyword dictionaries need to be loaded
+        to make the lexer functional again."""
         self._SQL_REGEX = []
         self._keywords = []
 

--- a/sqlparse/lexer.py
+++ b/sqlparse/lexer.py
@@ -99,14 +99,12 @@ class Lexer(metaclass=_LexerSingletonMetaclass):
                 text = text.decode(encoding)
             else:
                 try:
-                    text = text.decode("utf-8")
+                    text = text.decode('utf-8')
                 except UnicodeDecodeError:
-                    text = text.decode("unicode-escape")
+                    text = text.decode('unicode-escape')
         else:
-            raise TypeError(
-                "Expected text or file-like object, got {!r}"
-                .format(type(text))
-            )
+            raise TypeError("Expected text or file-like object, got {!r}".
+                            format(type(text)))
 
         iterable = enumerate(text)
         for pos, char in iterable:

--- a/sqlparse/lexer.py
+++ b/sqlparse/lexer.py
@@ -6,7 +6,7 @@
 # the BSD License: https://opensource.org/licenses/BSD-3-Clause
 
 """SQL Lexer"""
-
+import re
 # This code is based on the SqlLexer in pygments.
 # http://pygments.org/
 # It's separated from the rest of pygments to increase performance
@@ -56,7 +56,8 @@ class Lexer(metaclass=_LexerSingletonMetaclass):
 
     def set_SQL_REGEX(self, SQL_REGEX):
         """Set the list of regex that will parse the SQL."""
-        self._SQL_REGEX = SQL_REGEX
+        FLAGS = re.IGNORECASE | re.UNICODE
+        self._SQL_REGEX = [(re.compile(rx, FLAGS).match, tt) for rx, tt in SQL_REGEX]
 
     def add_keywords(self, keywords):
         """Add keyword dictionaries. Keywords are looked up in the same order

--- a/tests/test_keywords.py
+++ b/tests/test_keywords.py
@@ -2,6 +2,7 @@ import pytest
 
 from sqlparse import tokens
 from sqlparse.keywords import SQL_REGEX
+from sqlparse.lexer import Lexer
 
 
 class TestSQLREGEX:
@@ -9,5 +10,5 @@ class TestSQLREGEX:
                                         '1.', '-1.',
                                         '.1', '-.1'])
     def test_float_numbers(self, number):
-        ttype = next(tt for action, tt in SQL_REGEX if action(number))
+        ttype = next(tt for action, tt in Lexer()._SQL_REGEX if action(number))
         assert tokens.Number.Float == ttype

--- a/tests/test_keywords.py
+++ b/tests/test_keywords.py
@@ -1,7 +1,6 @@
 import pytest
 
 from sqlparse import tokens
-from sqlparse.keywords import SQL_REGEX
 from sqlparse.lexer import Lexer
 
 

--- a/tests/test_keywords.py
+++ b/tests/test_keywords.py
@@ -9,5 +9,5 @@ class TestSQLREGEX:
                                         '1.', '-1.',
                                         '.1', '-.1'])
     def test_float_numbers(self, number):
-        ttype = next(tt for action, tt in Lexer()._SQL_REGEX if action(number))
+        ttype = next(tt for action, tt in Lexer.get_default_instance()._SQL_REGEX if action(number))
         assert tokens.Number.Float == ttype

--- a/tests/test_parse.py
+++ b/tests/test_parse.py
@@ -494,7 +494,6 @@ def test_parenthesis():
 
 def test_configurable_syntax():
     sql = """select * from foo BACON SPAM EGGS;"""
-    # sql="""select * from mydb.mytable BACON SPAM EGGS;"""
     tokens = sqlparse.parse(sql)[0]
 
     assert list(

--- a/tests/test_parse.py
+++ b/tests/test_parse.py
@@ -491,12 +491,15 @@ def test_parenthesis():
                                                     T.Newline,
                                                     T.Punctuation]
 
+
 def test_configurable_keywords():
     sql = """select * from foo BACON SPAM EGGS;"""
     tokens = sqlparse.parse(sql)[0]
 
     assert list(
-        (t.ttype, t.value) for t in tokens if t.ttype not in sqlparse.tokens.Whitespace
+        (t.ttype, t.value)
+        for t in tokens
+        if t.ttype not in sqlparse.tokens.Whitespace
     ) == [
         (sqlparse.tokens.Keyword.DML, "select"),
         (sqlparse.tokens.Wildcard, "*"),
@@ -520,7 +523,9 @@ def test_configurable_keywords():
     Lexer().default_initialization()
 
     assert list(
-        (t.ttype, t.value) for t in tokens if t.ttype not in sqlparse.tokens.Whitespace
+        (t.ttype, t.value)
+        for t in tokens
+        if t.ttype not in sqlparse.tokens.Whitespace
     ) == [
         (sqlparse.tokens.Keyword.DML, "select"),
         (sqlparse.tokens.Wildcard, "*"),
@@ -539,7 +544,11 @@ def test_configurable_regex():
 
     my_regex = (r"ZORDER\s+BY\b", sqlparse.tokens.Keyword)
 
-    lex.set_SQL_REGEX(keywords.SQL_REGEX[:38] + [my_regex] + keywords.SQL_REGEX[38:])
+    lex.set_SQL_REGEX(
+        keywords.SQL_REGEX[:38]
+        + [my_regex]
+        + keywords.SQL_REGEX[38:]
+    )
     lex.add_keywords(keywords.KEYWORDS_COMMON)
     lex.add_keywords(keywords.KEYWORDS_ORACLE)
     lex.add_keywords(keywords.KEYWORDS_PLPGSQL)
@@ -553,5 +562,7 @@ def test_configurable_regex():
     Lexer().default_initialization()
 
     assert list(
-        (t.ttype, t.value) for t in tokens if t.ttype not in sqlparse.tokens.Whitespace
+        (t.ttype, t.value)
+        for t in tokens
+        if t.ttype not in sqlparse.tokens.Whitespace
     )[4] == (sqlparse.tokens.Keyword, "zorder by")

--- a/tests/test_parse.py
+++ b/tests/test_parse.py
@@ -509,7 +509,7 @@ def test_configurable_keywords():
         (sqlparse.tokens.Punctuation, ";"),
     ]
 
-    Lexer().add_keywords(
+    Lexer.get_default_instance().add_keywords(
         {
             "BACON": sqlparse.tokens.Name.Builtin,
             "SPAM": sqlparse.tokens.Keyword,
@@ -520,7 +520,7 @@ def test_configurable_keywords():
     tokens = sqlparse.parse(sql)[0]
 
     # reset the syntax for later tests.
-    Lexer().default_initialization()
+    Lexer.get_default_instance().default_initialization()
 
     assert list(
         (t.ttype, t.value)
@@ -539,7 +539,7 @@ def test_configurable_keywords():
 
 
 def test_configurable_regex():
-    lex = Lexer()
+    lex = Lexer.get_default_instance()
     lex.clear()
 
     my_regex = (r"ZORDER\s+BY\b", sqlparse.tokens.Keyword)
@@ -559,7 +559,7 @@ def test_configurable_regex():
     tokens = sqlparse.parse("select * from foo zorder by bar;")[0]
 
     # reset the syntax for later tests.
-    Lexer().default_initialization()
+    Lexer.get_default_instance().default_initialization()
 
     assert list(
         (t.ttype, t.value)

--- a/tests/test_parse.py
+++ b/tests/test_parse.py
@@ -1,5 +1,4 @@
 """Tests sqlparse.parse()."""
-import re
 from io import StringIO
 
 import pytest
@@ -538,10 +537,7 @@ def test_configurable_regex():
     lex = Lexer()
     lex.clear()
 
-    my_regex = (
-        re.compile(r"ZORDER\s+BY\b", keywords.FLAGS).match,
-        sqlparse.tokens.Keyword,
-    )
+    my_regex = (r"ZORDER\s+BY\b", sqlparse.tokens.Keyword)
 
     lex.set_SQL_REGEX(keywords.SQL_REGEX[:38] + [my_regex] + keywords.SQL_REGEX[38:])
     lex.add_keywords(keywords.KEYWORDS_COMMON)


### PR DESCRIPTION
This PR makes the `Lexer` a singleton class. This object carries the configured syntax as instance attributes. A library user who has non-standard syntax requirements is able to adapt the behavior of the `Lexer` to meet her needs. As an example for how to do this, please see the relevant test:
```python
def test_configurable_syntax():
    sql = """select * from foo BACON SPAM EGGS;"""
    tokens = sqlparse.parse(sql)[0]

    assert list(
        (t.ttype, t.value) for t in tokens if t.ttype not in sqlparse.tokens.Whitespace
    ) == [
        (sqlparse.tokens.Keyword.DML, "select"),
        (sqlparse.tokens.Wildcard, "*"),
        (sqlparse.tokens.Keyword, "from"),
        (None, "foo BACON"),
        (None, "SPAM EGGS"),
        (sqlparse.tokens.Punctuation, ";"),
    ]

    Lexer().add_keywords(
        {
            "BACON": sqlparse.tokens.Name.Builtin,
            "SPAM": sqlparse.tokens.Keyword,
            "EGGS": sqlparse.tokens.Keyword,
        }
    )

    tokens = sqlparse.parse(sql)[0]

    assert list(
        (t.ttype, t.value) for t in tokens if t.ttype not in sqlparse.tokens.Whitespace
    ) == [
        (sqlparse.tokens.Keyword.DML, "select"),
        (sqlparse.tokens.Wildcard, "*"),
        (sqlparse.tokens.Keyword, "from"),
        (None, "foo"),
        (sqlparse.tokens.Name.Builtin, "BACON"),
        (sqlparse.tokens.Keyword, "SPAM"),
        (sqlparse.tokens.Keyword, "EGGS"),
        (sqlparse.tokens.Punctuation, ";"),
    ]
    # reset the syntax for later tests.
    Lexer().default_initialization()
```