### PR TITLE
Add snowflake and bigquery keywords

### DIFF
--- a/sqlparse/keywords.py
+++ b/sqlparse/keywords.py
@@ -959,3 +959,35 @@ KEYWORDS_HQL = {
 KEYWORDS_MSACCESS = {
     'DISTINCTROW': tokens.Keyword,
 }
+
+
+KEYWORDS_SNOWFLAKE = {    
+    'ACCOUNT': tokens.Keyword,
+    'GSCLUSTER': tokens.Keyword,
+    'ISSUE': tokens.Keyword,
+    'ORGANIZATION': tokens.Keyword,
+    'PIVOT': tokens.Keyword,
+    'QUALIFY': tokens.Keyword,
+    'REGEXP': tokens.Keyword,
+    'RLIKE': tokens.Keyword,
+    'SAMPLE': tokens.Keyword,
+    'TRY_CAST': tokens.Keyword,
+    'UNPIVOT': tokens.Keyword,
+
+    'VARIANT': tokens.Name.Builtin,
+}
+
+
+KEYWORDS_BIGQUERY = {
+    'ASSERT_ROWS_MODIFIED': tokens.Keyword,
+    'DEFINE': tokens.Keyword,
+    'ENUM': tokens.Keyword,
+    'HASH': tokens.Keyword,
+    'LOOKUP': tokens.Keyword,
+    'PRECEDING': tokens.Keyword,
+    'PROTO': tokens.Keyword,
+    'RESPECT': tokens.Keyword,
+    'TABLESAMPLE': tokens.Keyword,
+
+    'BIGNUMERIC': tokens.Name.Builtin,
+}

--- a/sqlparse/lexer.py
+++ b/sqlparse/lexer.py
@@ -63,6 +63,8 @@ class Lexer:
         self.add_keywords(keywords.KEYWORDS_HQL)
         self.add_keywords(keywords.KEYWORDS_MSACCESS)
         self.add_keywords(keywords.KEYWORDS)
+        self.add_keywords(keywords.KEYWORDS_SNOWFLAKE)
+        self.add_keywords(keywords.KEYWORDS_BIGQUERY)
 
     def clear(self):
         """Clear all syntax configurations.


### PR DESCRIPTION
This PR adds 2 new dicts to extend sqlparse's lexer: 1 for Snowflake and 1 for BigQuery.
The proposed dicts are not exhaustive, and only add keywords not already covered by existing dicts.

The value of these keywords can be seen when parsing PIVOT or UNPIVOT statements. After this change, PIVOT subqueries are tokenized properly.
Example query to show value:
```
sql = """
WITH SUBSET AS (
  SELECT *
  FROM DB.SCHEMA.TABLE
  WHERE DATE >= '2021-11-15'
),
PIV AS (
  SELECT BUCKET, YES, NO, OTHER
  FROM (
    SELECT BUCKET, AMOUNT, INDICATOR
    FROM SUBSET
  )
  PIVOT ( SUM(AMOUNT) FOR INDICATOR IN ('YES', 'NO', 'OTHER') )
  AS p (BUCKET, YES, NO, OTHER)
)
SELECT * FROM PIV
"""
```