### PR TITLE
Add Chinese, Japanese, Korean Name support

### DIFF
--- a/sqlparse/keywords.py
+++ b/sqlparse/keywords.py
@@ -45,6 +45,9 @@ SQL_REGEX = [
     (r'(CASE|IN|VALUES|USING|FROM|AS)\b', tokens.Keyword),
 
     (r'(@|##|#)[A-ZÀ-Ü]\w+', tokens.Name),
+    (r'[\u4e00-\u9fa5]+', tokens.Name),  # 'Chinese Name'
+    (r'[\u0800-\u4e00]+', tokens.Name),  # 'Japanese Name'
+    (r'[\uac00-\ud7ff]+', tokens.Name),  # 'Korean Name'
 
     # see issue #39
     # Spaces around period `schema . name` are valid identifier


### PR DESCRIPTION
 #376 
 I add three regular expression to match Chinese, Japanese, Korean words . 
Now it can tokenize sql correctly like 'select T2.名称 , T2.南北区域 from 民风彪悍十大城市 as T1 join 省份 as T2 on 民风彪悍十大城市.所属省份id == 省份.词条id group by T1.所属省份id order by count ( * ) asc limit 3'