### PR TITLE
Fix token matching by always returning a tuple

### DIFF
--- a/sqlparse/sql.py
+++ b/sqlparse/sql.py
@@ -227,7 +227,7 @@ class TokenList(Token):
     def _token_matching(self, funcs, start=0, end=None, reverse=False):
         """next token that match functions"""
         if start is None:
-            return None
+            return None, None
 
         if not isinstance(funcs, (list, tuple)):
             funcs = (funcs,)

--- a/tests/test_tokenize.py
+++ b/tests/test_tokenize.py
@@ -114,6 +114,7 @@ def test_tokenlist_token_matching():
     assert x.token_matching([lambda t: t.ttype is T.Keyword], 0) == t1
     assert x.token_matching([lambda t: t.ttype is T.Punctuation], 0) == t2
     assert x.token_matching([lambda t: t.ttype is T.Keyword], 1) is None
+    assert x.token_matching([lambda t: t.ttype is T.Keyword], None) is None
 
 
 def test_stream_simple():


### PR DESCRIPTION
When `_token_matching` is given `start=None` it does an early exit, but it only return a single None instead of a tuple.

This PR ensure that _token_matching returns a tuple of None in such case

Fixes #747