### PR TITLE
Update extending.rst

### DIFF
--- a/docs/source/extending.rst
+++ b/docs/source/extending.rst
@@ -70,7 +70,7 @@ a keyword to the lexer:
     lex.add_keywords(keywords.KEYWORDS)
 
     # add a custom keyword dictionary
-    lex.add_keywords({'BAR', sqlparse.tokens.Keyword})
+    lex.add_keywords({'BAR': sqlparse.tokens.Keyword})
 
     # no configuration is passed here. The lexer is used as a singleton.
     sqlparse.parse("select * from foo zorder by bar;")


### PR DESCRIPTION
Fix broken example: https://sqlparse.readthedocs.io/en/latest/extending/

```python
def is_keyword(self, value):
        """Checks for a keyword.

        If the given value is in one of the KEYWORDS_* dictionary
        it's considered a keyword. Otherwise, tokens.Name is returned.
        """
        val = value.upper()
        for kwdict in self._keywords:
            if val in kwdict:
                return kwdict[val], value                      # <--------------------- dict expected, but in the example set is used
        else:
            return tokens.Name, value
```