### PR TITLE
allow operators to procede dollar quoted strings

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -14,6 +14,7 @@ Enhancements:
 Bug Fixes
 
 * Ignore dunder attributes when creating Tokens (issue672).
+* Allow operators to precede dollar-quoted strings (issue763).
 
 
 Release 0.4.4 (Apr 18, 2023)

--- a/sqlparse/keywords.py
+++ b/sqlparse/keywords.py
@@ -30,7 +30,7 @@ SQL_REGEX = [
 
     (r"`(``|[^`])*`", tokens.Name),
     (r"´(´´|[^´])*´", tokens.Name),
-    (r'((?<!\S)\$(?:[_A-ZÀ-Ü]\w*)?\$)[\s\S]*?\1', tokens.Literal),
+    (r'((?<![\w\"\$])\$(?:[_A-ZÀ-Ü]\w*)?\$)[\s\S]*?\1', tokens.Literal),
 
     (r'\?', tokens.Name.Placeholder),
     (r'%(\(\w+\))?s', tokens.Name.Placeholder),

--- a/tests/test_parse.py
+++ b/tests/test_parse.py
@@ -180,6 +180,14 @@ def test_psql_quotation_marks():
     $PROC_2$ LANGUAGE plpgsql;""")
     assert len(t) == 2
 
+    # operators are valid infront of dollar quoted strings
+    t = sqlparse.split("""UPDATE SET foo =$$bar;SELECT bar$$""")
+    assert len(t) == 1
+    
+    # identifiers must be separated by whitespace
+    t = sqlparse.split("""UPDATE SET foo TO$$bar;SELECT bar$$""")
+    assert len(t) == 2
+
 
 def test_double_precision_is_builtin():
     s = 'DOUBLE PRECISION'


### PR DESCRIPTION
# Thanks for contributing!

Before submitting your pull request please have a look at the
following checklist:

- [x] ran the tests (`pytest`)
- [ ] all style issues addressed (`flake8`)
- [x] your changes are covered by tests
- [ ] your changes are documented, if needed


Fixes #763
Currently string literals using dollar quoting (`$js$mytext$js$`) must be preceded by a whitespace character, which prevents e.g. using `SET application_name=$$foo;bar$$` which is valid PostgreSQL 