### PR TITLE
Optimize sqlparse.utils.imt().

### DIFF
--- a/sqlparse/utils.py
+++ b/sqlparse/utils.py
@@ -86,20 +86,23 @@ def imt(token, i=None, m=None, t=None):
     :param t: TokenType or Tuple/List of TokenTypes
     :return:  bool
     """
-    clss = i
-    types = [t, ] if t and not isinstance(t, list) else t
-    mpatterns = [m, ] if m and not isinstance(m, list) else m
-
     if token is None:
         return False
-    elif clss and isinstance(token, clss):
+    if i and isinstance(token, i):
         return True
-    elif mpatterns and any(token.match(*pattern) for pattern in mpatterns):
-        return True
-    elif types and any(token.ttype in ttype for ttype in types):
-        return True
-    else:
-        return False
+    if m:
+        if isinstance(m, list):
+            if any(token.match(*pattern) for pattern in m):
+                return True
+        elif token.match(*m):
+            return True
+    if t:
+        if isinstance(t, list):
+            if any(token.ttype in ttype for ttype in t):
+                return True
+        elif token.ttype in t:
+            return True
+    return False
 
 
 def consume(iterator, n):


### PR DESCRIPTION
# Thanks for contributing!

Before submitting your pull request please have a look at the
following checklist:

- [x] ran the tests (`pytest`)
- [x] all style issues addressed (`flake8`)
- [x] your changes are covered by tests
- [x] your changes are documented, if needed

Profiling a `sqlparse.parse()` on a bunch of large `SELECT` queries, 14ms out of 59ms, or ~24% of the time, was spent in `sqlparse.utils.imt()`.

Looking at that function, it did some moving of the `m` and `t` parameters into lists, wasting work when they’re not set or a single element which can use a faster check. To mitigate this, I optimized it to do the check only when the parameters are set, and avoid the listification of single elements.

This doubled its speed, saving 7ms in the same profile.
