### PR TITLE
Fixes #701: Add the OVER clause and include it in the Function tokens.

### DIFF
--- a/sqlparse/sql.py
+++ b/sqlparse/sql.py
@@ -623,7 +623,7 @@ class Function(NameAliasMixin, TokenList):
 
     def get_parameters(self):
         """Return a list of parameters."""
-        parenthesis = self.tokens[-1]
+        parenthesis = self.token_next_by(i=Parenthesis)[1]
         result = []
         for token in parenthesis.tokens:
             if isinstance(token, IdentifierList):
@@ -632,6 +632,13 @@ class Function(NameAliasMixin, TokenList):
                      t=T.Literal):
                 result.append(token)
         return result
+
+    def get_window(self):
+        """Return the window if it exists."""
+        over_clause = self.token_next_by(i=Over)
+        if not over_clause:
+            return None
+        return over_clause[1].tokens[-1]
 
 
 class Begin(TokenList):

--- a/sqlparse/sql.py
+++ b/sqlparse/sql.py
@@ -554,6 +554,11 @@ class Where(TokenList):
         'HAVING', 'RETURNING', 'INTO')
 
 
+class Over(TokenList):
+    """An OVER clause."""
+    M_OPEN = T.Keyword, 'OVER'
+
+
 class Having(TokenList):
     """A HAVING clause."""
     M_OPEN = T.Keyword, 'HAVING'

--- a/tests/test_grouping.py
+++ b/tests/test_grouping.py
@@ -392,6 +392,14 @@ def test_grouping_function():
     p = sqlparse.parse('foo(null, bar)')[0]
     assert isinstance(p.tokens[0], sql.Function)
     assert len(list(p.tokens[0].get_parameters())) == 2
+    p = sqlparse.parse('foo(5) over win1')[0]
+    assert isinstance(p.tokens[0], sql.Function)
+    assert len(list(p.tokens[0].get_parameters())) == 1
+    assert isinstance(p.tokens[0].get_window(), sql.Identifier)
+    p = sqlparse.parse('foo(5) over (PARTITION BY c1)')[0]
+    assert isinstance(p.tokens[0], sql.Function)
+    assert len(list(p.tokens[0].get_parameters())) == 1
+    assert isinstance(p.tokens[0].get_window(), sql.Parenthesis)
 
 
 def test_grouping_function_not_in():

--- a/tests/test_grouping.py
+++ b/tests/test_grouping.py
@@ -185,6 +185,20 @@ def test_grouping_identifier_function():
     assert isinstance(p.tokens[0], sql.Identifier)
     assert isinstance(p.tokens[0].tokens[0], sql.Operation)
     assert isinstance(p.tokens[0].tokens[0].tokens[0], sql.Function)
+    p = sqlparse.parse('foo(c1) over win1 as bar')[0]
+    assert isinstance(p.tokens[0], sql.Identifier)
+    assert isinstance(p.tokens[0].tokens[0], sql.Function)
+    assert len(p.tokens[0].tokens[0].tokens) == 4
+    assert isinstance(p.tokens[0].tokens[0].tokens[3], sql.Over)
+    assert isinstance(p.tokens[0].tokens[0].tokens[3].tokens[2],
+                      sql.Identifier)
+    p = sqlparse.parse('foo(c1) over (partition by c2 order by c3) as bar')[0]
+    assert isinstance(p.tokens[0], sql.Identifier)
+    assert isinstance(p.tokens[0].tokens[0], sql.Function)
+    assert len(p.tokens[0].tokens[0].tokens) == 4
+    assert isinstance(p.tokens[0].tokens[0].tokens[3], sql.Over)
+    assert isinstance(p.tokens[0].tokens[0].tokens[3].tokens[2],
+                      sql.Parenthesis)
 
 
 @pytest.mark.parametrize('s', ['foo+100', 'foo + 100', 'foo*100'])


### PR DESCRIPTION
Resolves #701 

- [x] ran the tests (`pytest`)
- [x] all style issues addressed (`flake8`)
- [x] your changes are covered by tests
(N/A) your changes are documented, if needed


Group tokens such as `OVER exist_win` or `OVER (PARTITION BY...)` as the `OVER clause` before grouping `Identifier` and `Function`. Extend tokens of `Function` to include the `OVER clause` if it is next to the `Parenthesis` of function parameters.
