### PR TITLE
Changelog: Fix incorrect PR number

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -21,7 +21,7 @@ Enhancements:
 
 * Splitting statements now allows to remove the semicolon at the end.
   Some database backends love statements without semicolon (issue742).
-* Support TypedLiterals in get_parameters (pr649, by Khrol).
+* Support TypedLiterals in get_parameters (pr749, by Khrol).
 * Improve splitting of Transact SQL when using GO keyword (issue762).
 * Support for some JSON operators (issue682).
 * Improve formatting of statements containing JSON operators (issue542).


### PR DESCRIPTION
Incorrect PR number was used in changelog. "Support TypedLiterals in get_parameters" was PR #749 not 649.

# Thanks for contributing!

- [ ] ran the tests (`pytest`)
- [ ] all style issues addressed (`flake8`)
- [ ] your changes are covered by tests
- [x] your changes are documented, if needed
