### PR TITLE
bugfix ISSUE_801; Remove all comments when only comments

### DIFF
--- a/sqlparse/filters/others.py
+++ b/sqlparse/filters/others.py
@@ -65,6 +65,7 @@ class StripCommentsFilter:
                 if prev_ is not None and not prev_.match(T.Punctuation, '('):
                     tlist.tokens.insert(tidx, _get_insert_token(token))
                 tlist.tokens.remove(token)
+                tidx -= 1
             else:
                 tlist.tokens[tidx] = _get_insert_token(token)
 

--- a/tests/test_format.py
+++ b/tests/test_format.py
@@ -61,6 +61,12 @@ class TestFormat:
               'from foo--comment\nf'
         res = sqlparse.format(sql, strip_comments=True)
         assert res == 'select a\nfrom foo\nf'
+        sql = '--A;--B;'
+        res = ''
+        assert res == sqlparse.format(sql, strip_comments=True)
+        sql = '--A;\n--B;'
+        res = ''
+        assert res == sqlparse.format(sql, strip_comments=True)
 
     def test_strip_comments_invalid_option(self):
         sql = 'select-- foo\nfrom -- bar\nwhere'
@@ -77,6 +83,12 @@ class TestFormat:
         sql = '/*\n * sql starts here\n */\nselect'
         res = sqlparse.format(sql, strip_comments=True)
         assert res == 'select'
+        sql = '/* sql starts here */'
+        res = sqlparse.format(sql, strip_comments=True)
+        assert res == ''
+        sql = '/* sql starts here */\n/* or here */'
+        res = sqlparse.format(sql, strip_comments=True, strip_whitespace=True)
+        assert res == ''
         sql = 'select (/* sql starts here */ select 2)'
         res = sqlparse.format(sql, strip_comments=True, strip_whitespace=True)
         assert res == 'select (select 2)'


### PR DESCRIPTION
Fixing issue #801. Format remove all the comments with strip_comments when there are only comments in a line.

Before submitting your pull request please have a look at the
following checklist:

- [-] ran the tests (`pytest`)
- [-] all style issues addressed (`flake8`)
- [-] your changes are covered by tests
- [-] your changes are documented, if needed

In addition, please take care to provide a proper description
on what your change does, fixes or achieves when submitting the 
pull request.