### PR TITLE
fix: Add `ATTACH`, `DETACH` to PostgreSQL keywords.

### DIFF
--- a/sqlparse/keywords.py
+++ b/sqlparse/keywords.py
@@ -839,6 +839,8 @@ KEYWORDS_PLPGSQL = {
     'CONFLICT': tokens.Keyword,
     'WINDOW': tokens.Keyword,
     'PARTITION': tokens.Keyword,
+    'ATTACH': tokens.Keyword,
+    'DETACH': tokens.Keyword,
     'OVER': tokens.Keyword,
     'PERFORM': tokens.Keyword,
     'NOTICE': tokens.Keyword,


### PR DESCRIPTION

## Summary

Examples of valid, not so rare statements in postgres dialect:

```
ALTER TABLE atable DETACH PARTITION atable_p00;
ALTER INDEX atable_acolumn_idx ATTACH PARTITION atable_p01_acolumn_idx;
```

They fall into same class as `EXTENSION` added in below PR, so let's add them as well.
https://github.com/andialbrecht/sqlparse/issues/785

WIP
