### PR TITLE
remove shebang from cli.py

### DIFF
--- a/sqlparse/cli.py
+++ b/sqlparse/cli.py
@@ -1,5 +1,3 @@
-#!/usr/bin/env python
-#
 # Copyright (C) 2009-2020 the sqlparse authors and contributors
 # <see AUTHORS file>
 #


### PR DESCRIPTION
We don't need shebang here cause there is the `__main__.py` file which allowed to run it as a script.

This doesn't directly interfere much, but I've encountered difficulties when my code tried to turn this module into a script (based on first line/shebang), although the file itself is not intended for this.

# Thanks for contributing!

Before submitting your pull request please have a look at the
following checklist:

- [x] ran the tests (`pytest`)
- [x] all style issues addressed (`flake8`)
- [x] your changes are covered by tests
- [x] your changes are documented, if needed

In addition, please take care to provide a proper description
on what your change does, fixes or achieves when submitting the 
pull request.