### PR TITLE
Add 'INTERSECT' to Close Keywords in Where clause

### DIFF
--- a/sqlparse/sql.py
+++ b/sqlparse/sql.py
@@ -550,8 +550,8 @@ class Where(TokenList):
     """A WHERE clause."""
     M_OPEN = T.Keyword, 'WHERE'
     M_CLOSE = T.Keyword, (
-        'ORDER BY', 'GROUP BY', 'LIMIT', 'UNION', 'UNION ALL', 'EXCEPT', 'INTERSECT',
-        'HAVING', 'RETURNING', 'INTO')
+        'ORDER BY', 'GROUP BY', 'LIMIT', 'UNION', 'UNION ALL', 'EXCEPT',
+        'INTERSECT', 'HAVING', 'RETURNING', 'INTO')
 
 
 class Over(TokenList):


### PR DESCRIPTION
# Thanks for contributing!

Before submitting your pull request please have a look at the
following checklist:

- [x] ran the tests (`pytest`)
- [x] all style issues addressed (`flake8`)
- [x] your changes are covered by tests
- [x] your changes are documented, if needed

"INTERSECT" must be a closing keyword for WhereConverter. Otherwise SQL Queries, which use that combination, cannot be parsed.
Docs: https://learn.microsoft.com/en-us/sql/t-sql/language-elements/set-operators-except-and-intersect-transact-sql?view=sql-server-ver17