### PR TITLE
Allow customizing lexer instance in FilterStack

### DIFF
--- a/sqlparse/engine/filter_stack.py
+++ b/sqlparse/engine/filter_stack.py
@@ -20,6 +20,7 @@ class FilterStack:
         self.stmtprocess = []
         self.postprocess = []
         self._grouping = False
+        self.lexer = lexer
         if strip_semicolon:
             self.stmtprocess.append(StripTrailingSemicolonFilter())
 
@@ -28,7 +29,7 @@ class FilterStack:
 
     def run(self, sql, encoding=None):
         try:
-            stream = lexer.tokenize(sql, encoding)
+            stream = self.lexer.tokenize(sql, encoding)
             # Process token stream
             for filter_ in self.preprocess:
                 stream = filter_.process(stream)


### PR DESCRIPTION
**Fixes #806**

This PR makes a subtle change to FilterStack that allows users to customize the lexer instance used for tokenization.

**Problem:**
The top-level entry points, notably sqlparse.parse(sql), use the singleton Lexer instance via FilterStack. Users that extend sqlparse (e.g., to parse SQL with a custom Lexer instance/subclass depending on the SQL's dialect) can't re-use top level functions/FilterStack, because they always use the singleton Lexer instance.

**Solution:**
Added a self.lexer attribute to FilterStack that defaults to the lexer module but can be overridden by users.

**Changes:**
- Added self.lexer = lexer in FilterStack.__init__()
- Changed run() method to use self.lexer.tokenize() instead of lexer.tokenize()

**Testing:**
- Verified that FilterStack has the lexer attribute
- Verified that the default lexer is the module-level lexer (backward compatible)
- Verified that users can override the lexer attribute with custom instances

This is a backward-compatible change that doesn't affect existing usage.