### PR TITLE
fix: convert tabs to spaces when stripping whitespace

### DIFF
--- a/sqlparse/filters/others.py
+++ b/sqlparse/filters/others.py
@@ -92,6 +92,9 @@ class StripWhitespaceFilter:
         is_first_char = True
         for token in tlist.tokens:
             if token.is_whitespace:
+                # Replace tabs with spaces
+                token.value = token.value.replace('\t', ' ')
+                # Then normalize whitespace (collapse multiple spaces)
                 token.value = '' if last_was_ws or is_first_char else ' '
             last_was_ws = token.is_whitespace
             is_first_char = False


### PR DESCRIPTION
## Summary

Fixes #823

When  (enabled by ), whitespace normalization already collapses runs of whitespace to a single space. However, tabs () could still be present in whitespace tokens and would not be normalized to spaces.

This PR converts tabs to spaces as part of  so formatting produces consistent indentation regardless of whether the input used tabs or spaces.

## Changes

- In , replace  with a space before whitespace normalization.

## Tests

- 