### PR TITLE
docs: fix tar command in installation instructions

### DIFF
--- a/docs/source/intro.rst
+++ b/docs/source/intro.rst
@@ -11,7 +11,7 @@ install the module system-wide run
 
 .. code-block:: bash
 
-   $ tar cvfz python-sqlparse-VERSION.tar.gz
+   $ tar xvfz python-sqlparse-VERSION.tar.gz
    $ cd python-sqlparse/
    $ sudo python setup.py install
 


### PR DESCRIPTION
The installation instructions had 'tar cvfz' which creates an archive, but the correct command to extract a downloaded archive is 'tar xvfz'.

- Changed 'cvfz' (create) to 'xvfz' (extract)

This fixes a documentation error that could confuse users following the installation instructions.