### PR TITLE
Add REFRESH keyword to KEYWORDS dictionary

### DIFF
--- a/sqlparse/keywords.py
+++ b/sqlparse/keywords.py
@@ -467,6 +467,7 @@ KEYWORDS = {
     'RELATIVE': tokens.Keyword,
     'RENAME': tokens.Keyword,
     'REPEATABLE': tokens.Keyword,
+    'REFRESH': tokens.Keyword,
     'RESET': tokens.Keyword,
     'RESOURCE': tokens.Keyword,
     'RESTART': tokens.Keyword,


### PR DESCRIPTION
## Summary

Adds the REFRESH keyword to the KEYWORDS dictionary to enable proper recognition of SQL statements like `REFRESH MATERIALIZED VIEW`.

## Changes

- Added 'REFRESH': tokens.Keyword to KEYWORDS dictionary in sqlparse/keywords.py

## Testing

```python
import sqlparse
sql = 'REFRESH MATERIALIZED VIEW my_view'
parsed = sqlparse.parse(sql)[0]
first_token = parsed.token_first(skip_cm=True)
assert first_token.ttype in sqlparse.tokens.Keyword  # Passes
```

Fixes #797
