### PR TITLE
fix: handle escaped backslashes in SQL string literals

### DIFF
--- a/sqlparse/keywords.py
+++ b/sqlparse/keywords.py
@@ -59,7 +59,7 @@ SQL_REGEX = [
     (r'(?![_A-ZÀ-Ü])-?(\d+(\.\d*)|\.\d+)(?![_A-ZÀ-Ü])',
      tokens.Number.Float),
     (r'(?![_A-ZÀ-Ü])-?\d+(?![_A-ZÀ-Ü])', tokens.Number.Integer),
-    (r"'(''|\\'|[^'])*'", tokens.String.Single),
+    (r"'(''|\\\\|\\'|[^'])*'", tokens.String.Single),
     # not a real string literal in ANSI SQL:
     (r'"(""|\\"|[^"])*"', tokens.String.Symbol),
     (r'(""|".*?[^\\]")', tokens.String.Symbol),

--- a/tests/test_tokenize.py
+++ b/tests/test_tokenize.py
@@ -245,3 +245,33 @@ def test_cli_commands():
     p = sqlparse.parse('\\copy')[0]
     assert len(p.tokens) == 1
     assert p.tokens[0].ttype == T.Command
+
+
+def test_escaped_backslash_in_string():
+    # issue814 - Escaped backslashes in string literals
+    sql = r"SELECT '\\\\', '\\\\'"
+    tokens = list(lexer.tokenize(sql))
+    # Should have: SELECT, space, string, comma, space, string
+    assert len(tokens) == 6
+    assert tokens[0] == (T.Keyword.DML, 'SELECT')
+    assert tokens[1] == (T.Whitespace, ' ')
+    # The string contains two backslashes in the SQL, which is represented
+    # as 4 backslashes in the Python raw string
+    assert tokens[2] == (T.Literal.String.Single, "'\\\\\\\\'")
+    assert tokens[3] == (T.Punctuation, ',')
+    assert tokens[4] == (T.Whitespace, ' ')
+    assert tokens[5] == (T.Literal.String.Single, "'\\\\\\\\'")
+
+
+def test_escaped_quote_in_string():
+    # Test that escaped quotes still work
+    sql = r"SELECT 'it''s a test'"
+    tokens = list(lexer.tokenize(sql))
+    assert tokens[2] == (T.Literal.String.Single, "'it''s a test'")
+
+
+def test_backslash_escaped_quote_in_string():
+    # Test backslash-escaped quotes
+    sql = r"SELECT 'it\'s a test'"
+    tokens = list(lexer.tokenize(sql))
+    assert tokens[2] == (T.Literal.String.Single, "'it\\'s a test'")


### PR DESCRIPTION
The tokenizer regex for single-quoted strings didn't properly handle escaped backslashes (\\). This caused strings containing escaped backslashes to be parsed incorrectly.

This fix adds \\ to the regex pattern to properly match escaped backslashes within string literals.

Fixes #814