### PR TITLE
Fix tokenization of escaped backslashes in SQL string literals

### DIFF
--- a/sqlparse/keywords.py
+++ b/sqlparse/keywords.py
@@ -59,9 +59,9 @@ SQL_REGEX = [
     (r'(?![_A-ZÀ-Ü])-?(\d+(\.\d*)|\.\d+)(?![_A-ZÀ-Ü])',
      tokens.Number.Float),
     (r'(?![_A-ZÀ-Ü])-?\d+(?![_A-ZÀ-Ü])', tokens.Number.Integer),
-    (r"'(''|\\'|[^'])*'", tokens.String.Single),
+    (r"'(''|\\'|\\\\|[^'])*'", tokens.String.Single),
     # not a real string literal in ANSI SQL:
-    (r'"(""|\\"|[^"])*"', tokens.String.Symbol),
+    (r'"(""|\\"|\\\\|[^"])*"', tokens.String.Symbol),
     (r'(""|".*?[^\\]")', tokens.String.Symbol),
     # sqlite names can be escaped with [square brackets]. left bracket
     # cannot be preceded by word character or a right bracket --

--- a/tests/test_tokenize.py
+++ b/tests/test_tokenize.py
@@ -99,6 +99,21 @@ def test_single_quotes():
     assert repr(p.tokens[0])[:len(tst)] == tst
 
 
+def test_single_quotes_escaped_backslash():
+    # issue 814 - Incorrect Tokenization of Escaped Backslashes
+    # A string containing an escaped backslash (\\) should be tokenized
+    # as a single string literal, not split incorrectly.
+    sql = r"SELECT '\\', '\\'"
+    tokens = list(lexer.tokenize(sql))
+    # Should be: SELECT, ws, '\\', ,, ws, '\\'
+    assert tokens[0] == (T.Keyword.DML, 'SELECT')
+    assert tokens[1] == (T.Whitespace, ' ')
+    assert tokens[2] == (T.String.Single, "'\\\\'")
+    assert tokens[3] == (T.Punctuation, ',')
+    assert tokens[4] == (T.Whitespace, ' ')
+    assert tokens[5] == (T.String.Single, "'\\\\'")
+
+
 def test_tokenlist_first():
     p = sqlparse.parse(' select foo')[0]
     first = p.token_first()


### PR DESCRIPTION
Fixes #814

## Problem
Escaped backslashes in SQL string literals were not being tokenized correctly. For example, the query:

```python
SELECT '\\', '\\'
```

currently results in incorrect tokenization where the two string literals are merged together with the comma.

## Root Cause
The regex pattern for matching single-quoted strings did not handle escaped backslashes (`\\`) as a valid sequence within the string. When a backslash followed by a quote was encountered, it was interpreted as an escape sequence, but standalone escaped backslashes weren't properly consumed.

## Solution
Added `\\\\` to the string literal patterns to match escaped backslashes (`\\`) as valid content within string literals. This ensures that:
- `'\\'` is tokenized as a single string containing one backslash
- `'\\', '\\'` is correctly tokenized as two separate string literals

## Changes
- Modified `sqlparse/keywords.py`: Added `\\\\` to `String.Single` and `String.Symbol` patterns
- Added test case in `tests/test_tokenize.py` for escaped backslash tokenization

All existing tests continue to pass.