### PR TITLE
Fix end unconditionally decrementing the split level, but case not incrementing it in a plain select

### DIFF
--- a/sqlparse/engine/statement_splitter.py
+++ b/sqlparse/engine/statement_splitter.py
@@ -80,10 +80,12 @@ class StatementSplitter:
                 self._in_case = False
             return -1
 
-        if (unified in ('IF', 'FOR', 'WHILE', 'CASE')
+        if unified == 'CASE':
+            self._in_case = True
+            return 1
+
+        if (unified in ('IF', 'FOR', 'WHILE')
                 and self._is_create and self._begin_depth > 0):
-            if unified == 'CASE':
-                self._in_case = True
             return 1
 
         if unified in ('END IF', 'END FOR', 'END WHILE'):

--- a/tests/test_split.py
+++ b/tests/test_split.py
@@ -284,3 +284,34 @@ TRANSACTION;"""
     assert stmts[1].startswith('DELETE')
     assert stmts[2].startswith('INSERT')
     assert stmts[3] == 'END\nTRANSACTION;'
+
+
+def test_splitlevel_case_end():
+    # CASE in a plain SELECT did not increment the level, but its matching END
+    # decremented it unconditionally. This led to levels being wrong after the
+    # CASE WHEN ... END block.
+    s = sqlparse.engine.statement_splitter.StatementSplitter()
+    level = s.level
+
+    token_stream = [
+        (sqlparse.tokens.Keyword.DML, 'SELECT'),
+        (sqlparse.tokens.Keyword,     'CASE'),
+        (sqlparse.tokens.Keyword,     'WHEN'),
+        (sqlparse.tokens.Name,        'foo'),
+        (sqlparse.tokens.Keyword,     'THEN'),
+        (sqlparse.tokens.Number,      '1'),
+        (sqlparse.tokens.Keyword,     'END'),
+        (sqlparse.tokens.Keyword,     'FROM'),
+        (sqlparse.tokens.Name,        't'),
+    ]
+
+    for ttype, value in token_stream:
+        level += s._change_splitlevel(ttype, value)
+
+    assert level == 0
+
+    # This issue could lead to incorrectly treating a semicolon inside a text
+    # literal as a statement terminator and incorrectly splitting the query.
+    assert len(sqlparse.parse(
+        "SELECT CASE WHEN 1 THEN 2 END, test IN ('foo \\', 'foo;') FROM t"
+    )) == 1


### PR DESCRIPTION
Fixes inconsistent level handling of CASE ... END:
- CASE only sets the `_in_case` flag and returns a +1 level diff if it's in a CREATE statement
- the matching END unconditionally decreases the level

This led to the level being one lower than it should have been after the CASE WHEN ... END block.

The way this caused trouble was in splitting: combined with some escaping trouble (#838) this led to a query incorrectly being split into two.

Checklist:

- [x] ran the tests (`pytest`)
- [x] all style issues addressed (`flake8`)
- [x] your changes are covered by tests
- [x] your changes are documented, if needed