### PR TITLE
Fix BEGIN READ WRITE regression for Redshift syntax

### DIFF
--- a/sqlparse/engine/statement_splitter.py
+++ b/sqlparse/engine/statement_splitter.py
@@ -132,7 +132,8 @@ class StatementSplitter:
                 (ttype is T.Keyword or ttype is T.Name) and \
                 unified in ('TRANSACTION', 'WORK', 'TRAN',
                             'DISTRIBUTED', 'DEFERRED',
-                            'IMMEDIATE', 'EXCLUSIVE'):
+                            'IMMEDIATE', 'EXCLUSIVE',
+                            'ISOLATION', 'READ'):
             self._seen_begin = False
             if self._block_stack and self._block_stack[-1] == 'BEGIN':
                 self._block_stack.pop()

--- a/tests/test_split.py
+++ b/tests/test_split.py
@@ -285,6 +285,33 @@ TRANSACTION;"""
     assert stmts[2].startswith('INSERT')
     assert stmts[3] == 'END\nTRANSACTION;'
 
+# https://github.com/andialbrecht/sqlparse/issues/843
+def test_split_begin_read_write():
+    # Redshift BEGIN READ WRITE should not be treated as a block start
+    sql = """BEGIN READ WRITE;
+DELETE FROM schema.table_a USING table_a_temp
+WHERE schema.table_a.id = table_a_temp.id;
+INSERT INTO schema.table_a SELECT * FROM table_a_temp;
+END TRANSACTION;"""
+    stmts = sqlparse.split(sql)
+    assert len(stmts) == 4
+    assert stmts[0] == 'BEGIN READ WRITE;'
+    assert stmts[1].startswith('DELETE')
+    assert stmts[2].startswith('INSERT')
+    assert stmts[3] == 'END TRANSACTION;'
+
+
+# https://github.com/andialbrecht/sqlparse/issues/843
+def test_split_begin_isolation_level_read_only():
+    sql = """BEGIN ISOLATION LEVEL SERIALIZABLE READ ONLY;
+SELECT 1;
+END TRANSACTION;"""
+    stmts = sqlparse.split(sql)
+    assert len(stmts) == 3
+    assert stmts[0] == 'BEGIN ISOLATION LEVEL SERIALIZABLE READ ONLY;'
+    assert stmts[1] == 'SELECT 1;'
+    assert stmts[2] == 'END TRANSACTION;'
+
 
 def test_split_anonymous_begin_end_for():  # issue845 Case 1
     sql = """
@@ -372,5 +399,3 @@ def test_split_standalone_for_update():
     assert len(stmts) == 2
     assert stmts[0] == "SELECT * FROM foo FOR UPDATE;"
     assert stmts[1] == "SELECT 3;"
-
-


### PR DESCRIPTION
Redshift allows BEGIN with transaction mode modifiers such as READ WRITE or ISOLATION LEVEL. Treat those tokens like transaction starters so split() does not mistake BEGIN for a procedural block.

# Thanks for contributing!

Before submitting your pull request please have a look at the
following checklist:

- [x] ran the tests (`pytest`)
- [x] all style issues addressed (`flake8`)
- [x] your changes are covered by tests
- [x] your changes are documented, if needed

Described in https://github.com/andialbrecht/sqlparse/issues/843

---

**Note:** This repository has automated AI code reviews enabled to help catch
potential issues early and provide suggestions. This is an experimental
feature to support maintainers and contributors – your feedback is welcome!