### PR TITLE
avoid quadratic group value recomputation in TokenList

### DIFF
--- a/sqlparse/sql.py
+++ b/sqlparse/sql.py
@@ -164,7 +164,7 @@ class TokenList(Token):
     def __init__(self, tokens=None):
         self.tokens = tokens or []
         [setattr(token, 'parent', self) for token in self.tokens]
-        super().__init__(None, str(self))
+        super().__init__(None, ''.join(token.value for token in self.tokens))
         self.is_group = True
 
     def __str__(self):
@@ -327,7 +327,7 @@ class TokenList(Token):
             grp = start
             grp.tokens.extend(subtokens)
             del self.tokens[start_idx + 1:end_idx]
-            grp.value = str(start)
+            grp.value += ''.join(token.value for token in subtokens)
         else:
             subtokens = self.tokens[start_idx:end_idx]
             grp = grp_cls(subtokens)


### PR DESCRIPTION
group_tokens and TokenList.__init__ recompute a group's value by deep-flattening its whole subtree, so grouping an N-element identifier list is O(N^2): a 4000-column SELECT (~23 KB, under the 10000-token cap) takes ~1.8s to parse. Build the value from the direct children's already-current values and append only the newly added tokens on extend. Linear time, byte-identical parse output, full test suite passes.