### PR TITLE
escape backslashes in python and php output filters

### DIFF
--- a/sqlparse/filters/output.py
+++ b/sqlparse/filters/output.py
@@ -62,9 +62,9 @@ class OutputPythonFilter(OutputFilter):
                     yield sql.Token(T.Whitespace, after_lb)
                 continue
 
-            # Token has escape chars
-            elif "'" in token.value:
-                token.value = token.value.replace("'", "\\'")
+            # Token has chars that need escaping in a single-quoted string
+            elif "'" in token.value or "\\" in token.value:
+                token.value = token.value.replace("\\", "\\\\").replace("'", "\\'")
 
             # Put the token
             yield sql.Token(T.Text, token.value)
@@ -111,9 +111,9 @@ class OutputPHPFilter(OutputFilter):
                     yield sql.Token(T.Whitespace, after_lb)
                 continue
 
-            # Token has escape chars
-            elif '"' in token.value:
-                token.value = token.value.replace('"', '\\"')
+            # Token has chars that need escaping in a double-quoted string
+            elif '"' in token.value or "\\" in token.value:
+                token.value = token.value.replace("\\", "\\\\").replace('"', '\\"')
 
             # Put the token
             yield sql.Token(T.Text, token.value)


### PR DESCRIPTION
OutputPythonFilter and OutputPHPFilter in filters/output.py escape the wrapping quote but not backslashes, so a backslash in the SQL gets reinterpreted (\n, \t) and a trailing backslash escapes the closing quote, breaking out of the generated string literal. Escape backslashes before the quote in both filters.