### PR TITLE
Strip all whitespace before commas in reindented identifier lists

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -15,6 +15,11 @@ Bug Fixes
 
 * Fix statement splitting (issue845).
 * Fix a late-binding closure bug in `TokenList.token_not_matching`.
+* Fix non-idempotent reindent output when a comma in an identifier list is
+  preceded by more than one whitespace token (e.g. ``a  ,  b``). Previously
+  only a single whitespace token before a comma was stripped, leaving a stray
+  space that was removed on a subsequent format pass. All whitespace before a
+  comma is now removed.
 
 
 Release 0.5.5 (Dec 19, 2025)

--- a/sqlparse/filters/others.py
+++ b/sqlparse/filters/others.py
@@ -98,12 +98,18 @@ class StripWhitespaceFilter:
             is_first_char = False
 
     def _stripws_identifierlist(self, tlist):
-        # Removes newlines before commas, see issue140
-        last_nl = None
+        # Removes whitespace before commas, see issue140. All consecutive
+        # whitespace tokens before a comma are removed so that the result is
+        # stable when the formatter is applied to its own output (issue140
+        # only handled a single preceding whitespace token, which left a
+        # stray space when the comma was preceded by multiple whitespace
+        # tokens, e.g. ``a  ,  b``).
+        last_ws = []
         for token in list(tlist.tokens):
-            if last_nl and token.ttype is T.Punctuation and token.value == ',':
-                tlist.tokens.remove(last_nl)
-            last_nl = token if token.is_whitespace else None
+            if last_ws and token.ttype is T.Punctuation and token.value == ',':
+                for ws in last_ws:
+                    tlist.tokens.remove(ws)
+            last_ws = last_ws + [token] if token.is_whitespace else []
 
             # next_ = tlist.token_next(token, skip_ws=False)
             # if (next_ and not next_.is_whitespace and

--- a/tests/test_format.py
+++ b/tests/test_format.py
@@ -491,6 +491,27 @@ class TestFormatReindent:
             'from a,',
             '     b'])
 
+    def test_identifier_list_whitespace_before_comma(self):
+        # issue140 only removed a single whitespace token before a comma, so
+        # input with multiple whitespace tokens before a comma left a stray
+        # space (``a ,``) which made formatting non-idempotent. All whitespace
+        # before a comma must be removed.
+        f = lambda sql: sqlparse.format(sql, reindent=True)
+        expected = '\n'.join([
+            'select a,',
+            '       b',
+            'from t'])
+        for s in (
+            'select a  ,  b from t',   # multiple spaces before comma
+            'select a   , b from t',   # several spaces before comma
+            'select a\t\t, b from t',  # tabs before comma
+            'select a \n , b from t',  # newline + space before comma
+        ):
+            formatted = f(s)
+            assert formatted == expected
+            # formatting must be idempotent
+            assert f(formatted) == formatted
+
     def test_identifier_list_with_wrap_after(self):
         f = lambda sql: sqlparse.format(sql, reindent=True, wrap_after=14)
         s = 'select foo, bar, baz from table1, table2 where 1 = 2'


### PR DESCRIPTION
## Summary

Reindenting an identifier list is not idempotent when a comma is preceded by
more than one whitespace token. Re-formatting the formatter's own output
changes it, which it should not:

```python
>>> import sqlparse
>>> a = sqlparse.format("select a  ,  b from t", reindent=True)
>>> a
'select a ,\n       b\nfrom t'          # note the stray space before the comma
>>> sqlparse.format(a, reindent=True)
'select a,\n       b\nfrom t'          # the space is gone on a second pass
```

So `format(format(sql)) != format(sql)`. The single-whitespace case
(`select a , b`) already hugs the comma (`a,`) and is idempotent, which shows
the stable output the multi-whitespace case should also produce.

## Root cause

`StripWhitespaceFilter._stripws_identifierlist` (`sqlparse/filters/others.py`)
removes whitespace before commas (the original fix for issue140), but only
tracked **the single most recent** whitespace token:

```python
last_nl = None
for token in list(tlist.tokens):
    if last_nl and token.ttype is T.Punctuation and token.value == ',':
        tlist.tokens.remove(last_nl)
    last_nl = token if token.is_whitespace else None
```

When a comma is preceded by several whitespace tokens (multiple spaces, tabs,
or a newline followed by a space), only the last one is removed. The remaining
whitespace token is then collapsed to a single space by
`_stripws_default`, leaving the stray `a ,`.

## Fix

Track the full run of consecutive whitespace tokens before a comma and remove
all of them, so the comma always hugs the preceding token:

```python
last_ws = []
for token in list(tlist.tokens):
    if last_ws and token.ttype is T.Punctuation and token.value == ',':
        for ws in last_ws:
            tlist.tokens.remove(ws)
    last_ws = last_ws + [token] if token.is_whitespace else []
```

Only whitespace **before** a comma is removed, so `comma_first` spacing
(whitespace after a comma) is unaffected.

As a beneficial side effect this also resolves the extra-space output reported
in #644 (`comma_first` / `reindent_aligned` producing `select * ,`).

## Test evidence

Added `TestFormatReindent.test_identifier_list_whitespace_before_comma`
covering multiple spaces, several spaces, tabs, and newline+space before a
comma, asserting both the expected output and idempotency. The new test fails
on the current code and passes with the fix.

```
$ pytest -q
486 passed, 2 xfailed, 1 xpassed
$ ruff check sqlparse/
All checks passed!
```

## Checklist

- [x] ran the tests (`pytest`)
- [x] all style issues addressed (`ruff`)
- [x] your changes are covered by tests
- [x] your changes are documented, if needed (CHANGELOG entry added)
