### PR TITLE
fix quadratic reindent of wide identifier lists

### DIFF
--- a/sqlparse/filters/reindent.py
+++ b/sqlparse/filters/reindent.py
@@ -139,26 +139,30 @@ class ReindentFilter:
         if not tlist.within(sql.Function) and not tlist.within(sql.Values):
             with offset(self, num_offset):
                 position = 0
+                # Walk the identifiers in order and keep a cursor into the
+                # token list so token_index() doesn't rescan from the start on
+                # every insertion (that made wide lists O(n^2)).
+                last_idx = 0
                 for token in identifiers:
                     # Add 1 for the "," separator
                     position += len(token.value) + 1
                     if position > (self.wrap_after - self.offset):
                         adjust = 0
+                        tidx = tlist.token_index(token, last_idx)
                         if self.comma_first:
                             adjust = -2
-                            _, comma = tlist.token_prev(
-                                tlist.token_index(token))
+                            tidx, comma = tlist.token_prev(tidx)
                             if comma is None:
                                 continue
-                            token = comma
-                        tlist.insert_before(token, self.nl(offset=adjust))
+                        tlist.insert_before(tidx, self.nl(offset=adjust))
+                        last_idx = tidx
                         if self.comma_first:
                             _, ws = tlist.token_next(
-                                tlist.token_index(token), skip_ws=False)
+                                tidx + 1, skip_ws=False)
                             if (ws is not None
                                     and ws.ttype is not T.Text.Whitespace):
                                 tlist.insert_after(
-                                    token, sql.Token(T.Whitespace, ' '))
+                                    tidx + 1, sql.Token(T.Whitespace, ' '))
                         position = 0
         else:
             # ensure whitespace

--- a/sqlparse/sql.py
+++ b/sqlparse/sql.py
@@ -307,7 +307,7 @@ class TokenList(Token):
     def token_index(self, token, start=0):
         """Return list index of token."""
         start = start if isinstance(start, int) else self.token_index(start)
-        return start + self.tokens[start:].index(token)
+        return self.tokens.index(token, start)
 
     def group_tokens(self, grp_cls, start, end, include_end=True,
                      extend=False):


### PR DESCRIPTION
1. `ReindentFilter._process_identifierlist` puts each column on its own line via `insert_before(token)`, which resolves the position through `TokenList.token_index`.
2. `token_index` ran `self.tokens[start:].index(token)`, copying the list tail and rescanning from `0` on every call, so an N-column list reindented in O(n^2).

`repro`: `sqlparse.format('select ' + ','.join('a' for _ in range(16000)), reindent=True)`
`before`: reindent step ~3.5s; a 4000-column `SELECT` (~8 KB, under the 10000-token cap) ~0.5s
`after`: reindent step ~0.12s; same 4000-column `SELECT` ~0.2s

`fix`: `token_index` now uses `self.tokens.index(token, start)` (no copy, honours the hint) and the loop keeps a forward cursor. Parse output is unchanged.
