### PR TITLE
Keep OFFSET ... FETCH paging clause on one line with reindent_aligned (fixes #842)

### DIFF
--- a/sqlparse/filters/aligned_indent.py
+++ b/sqlparse/filters/aligned_indent.py
@@ -15,12 +15,18 @@ class AlignedIndentFilter:
                   r'(INNER\s+|OUTER\s+|STRAIGHT\s+)?|'
                   r'(CROSS\s+|NATURAL\s+)?)?JOIN\b')
     by_words = r'(GROUP|ORDER)\s+BY\b'
-    split_words = ('FROM',
-                   join_words, 'ON', by_words,
-                   'WHERE', 'AND', 'OR',
-                   'HAVING', 'LIMIT',
-                   'UNION', 'VALUES',
-                   'SET', 'BETWEEN', 'EXCEPT')
+    # Keywords that start a new aligned line. They are matched as regular
+    # expressions (see ``_next_token``), and ``Token.match`` uses an
+    # unanchored ``search``, so each bare keyword is wrapped in word
+    # boundaries. Without them ``ON`` matches inside ``ONLY`` and ``SET``
+    # inside ``OFFSET``, which broke the ``OFFSET ... FETCH NEXT n ROWS ONLY``
+    # paging clause across lines (issue #842).
+    split_words = (r'\bFROM\b',
+                   join_words, r'\bON\b', by_words,
+                   r'\bWHERE\b', r'\bAND\b', r'\bOR\b',
+                   r'\bHAVING\b', r'\bLIMIT\b', r'\bOFFSET\b',
+                   r'\bUNION\b', r'\bVALUES\b',
+                   r'\bSET\b', r'\bBETWEEN\b', r'\bEXCEPT\b')
 
     def __init__(self, char=' ', n='\n'):
         self.n = n

--- a/tests/test_format.py
+++ b/tests/test_format.py
@@ -345,6 +345,19 @@ class TestFormatReindentAligned:
             '(PARTITION BY b, c ORDER BY d DESC) as row_num',
             '  from table'])
 
+    def test_offset_fetch(self):
+        # the OFFSET ... FETCH NEXT n ROWS ONLY paging clause should stay on
+        # a single aligned line and not be split by substring matches of the
+        # clause keywords (ON in ONLY, SET in OFFSET) -- issue #842
+        sql = ('select id from tbl where id > 0 order by id asc '
+               'offset 0 rows fetch next 100 rows only')
+        assert self.formatter(sql) == '\n'.join([
+            'select id',
+            '  from tbl',
+            ' where id > 0',
+            ' order by id asc',
+            'offset 0 rows fetch next 100 rows only'])
+
 
 class TestSpacesAroundOperators:
     @staticmethod


### PR DESCRIPTION
## Description

`sqlparse.format(..., reindent_aligned=True)` (i.e. `sqlformat -a`) breaks the SQL:2008 `OFFSET ... FETCH NEXT n ROWS ONLY` paging clause across two lines, orphaning `ONLY` on its own indented line. Fixes #842.

**Before**
```
$ echo "SELECT id FROM tbl WHERE id > 0 ORDER BY id ASC OFFSET 0 ROWS FETCH NEXT 100 ROWS ONLY" | sqlformat -k upper -a -
SELECT id
  FROM tbl
 WHERE id > 0
 ORDER BY id ASC
OFFSET 0 ROWS FETCH NEXT 100 ROWS
  ONLY
```

**After**
```
SELECT id
  FROM tbl
 WHERE id > 0
 ORDER BY id ASC
OFFSET 0 ROWS FETCH NEXT 100 ROWS ONLY
```

## Root cause

`AlignedIndentFilter.split_words` lists the clause keywords that begin a new aligned line. They are matched as regular expressions, and `Token.match` matches with an **unanchored** `re.search`, so the bare keywords match *substrings*:

- `ON` matched inside `ONLY` → a newline was inserted before `ONLY`
- `SET` matched inside `OFFSET` → `OFFSET` only got its own line by accident

(`OR` likewise matches inside `ORDER BY`, although that was masked by the dedicated `(GROUP|ORDER) BY` pattern.)

## Fix

Wrap the bare clause keywords in `\b` word boundaries so they match whole keywords only, and add `OFFSET` as an explicit clause opener so the paging clause is aligned like `LIMIT` and stays on one line.

## Checklist
- [x] ran the tests (`pytest`) — 488 passed, 2 xfailed, 1 xpassed
- [x] all style issues addressed (`ruff check sqlparse/` clean for the changed file)
- [x] changes are covered by tests — added `TestFormatReindentAligned::test_offset_fetch` (fails before, passes after)
- [x] documented, if needed — n/a (internal formatter behaviour)