### PR TITLE
fix: recognize BEGIN READ WRITE/ONLY as transaction statements

### DIFF
--- a/sqlparse/engine/statement_splitter.py
+++ b/sqlparse/engine/statement_splitter.py
@@ -132,7 +132,8 @@ class StatementSplitter:
                 (ttype is T.Keyword or ttype is T.Name) and \
                 unified in ('TRANSACTION', 'WORK', 'TRAN',
                             'DISTRIBUTED', 'DEFERRED',
-                            'IMMEDIATE', 'EXCLUSIVE'):
+                            'IMMEDIATE', 'EXCLUSIVE',
+                            'READ'):
             self._seen_begin = False
             if self._block_stack and self._block_stack[-1] == 'BEGIN':
                 self._block_stack.pop()

--- a/tests/test_split.py
+++ b/tests/test_split.py
@@ -286,6 +286,30 @@ TRANSACTION;"""
     assert stmts[3] == 'END\nTRANSACTION;'
 
 
+@pytest.mark.parametrize('mode', ['READ WRITE', 'READ ONLY'])
+def test_split_begin_read_transaction(mode):  # issue843
+    sql = f"""BEGIN {mode};
+SELECT 1;
+COMMIT;"""
+    stmts = sqlparse.split(sql)
+    assert len(stmts) == 3
+    assert stmts[0] == f'BEGIN {mode};'
+    assert stmts[1] == 'SELECT 1;'
+    assert stmts[2] == 'COMMIT;'
+
+
+@pytest.mark.parametrize('keyword', ['WRITE', 'ONLY'])
+def test_split_begin_invalid_transaction_keyword_as_block(keyword):
+    sql = f"""BEGIN {keyword};
+SELECT 1;
+END;
+SELECT 2;"""
+    stmts = sqlparse.split(sql)
+    assert len(stmts) == 2
+    assert stmts[0].startswith(f'BEGIN {keyword};')
+    assert stmts[1] == 'SELECT 2;'
+
+
 def test_split_anonymous_begin_end_for():  # issue845 Case 1
     sql = """
 BEGIN


### PR DESCRIPTION
The statement splitter checks if a keyword immediately after
`BEGIN` is a transaction keyword to distinguish transaction
statements from PL/SQL blocks.  `READ`, `ONLY`, and `WRITE`
were missing from this list, causing Redshift's `BEGIN READ WRITE`
(and standard SQL `BEGIN READ ONLY`) to be treated as block starts
instead of standalone transaction statements.

As a result, `split()` would return the entire block content as
a single statement instead of correctly splitting at each semicolon.

Fixes: #843