### PR TITLE
Preserve trailing whitespace after the final semicolon

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -33,6 +33,8 @@ Bug Fixes
 
 * Fix statement splitting (issue845).
 * Fix a late-binding closure bug in `TokenList.token_not_matching`.
+* Preserve trailing whitespace after the final ``;`` so that
+  ``str(parse(sql)) == sql`` holds for input ending in a newline.
 
 
 Release 0.5.5 (Dec 19, 2025)

--- a/sqlparse/engine/statement_splitter.py
+++ b/sqlparse/engine/statement_splitter.py
@@ -152,6 +152,14 @@ class StatementSplitter:
         """Process the stream"""
         EOS_TTYPE = T.Whitespace, T.Comment.Single
 
+        # A finished statement is held back for one segment instead of being
+        # yielded immediately. This lets whitespace that turns out to trail the
+        # whole input be reattached to the statement it follows, rather than
+        # being split off into a dangling all-whitespace buffer that is dropped
+        # at end of stream (which silently broke ``str(parse(sql)) == sql`` for
+        # any input ending in a newline after ``;``).
+        held_tokens = None
+
         # Run over all stream tokens
         for ttype, value in stream:
             # Yield token if we finished a statement and there's no whitespaces
@@ -159,7 +167,12 @@ class StatementSplitter:
             # whitespace ignores newlines.
             # why don't multi line comments also count?
             if self.consume_ws and ttype not in EOS_TTYPE:
-                yield sql.Statement(self.tokens)
+                # A new statement starts here, so the previously held one is
+                # now known to be complete (its trailing whitespace, if any,
+                # already leads this new statement) and can be emitted.
+                if held_tokens is not None:
+                    yield sql.Statement(held_tokens)
+                held_tokens = self.tokens
 
                 # Reset filter and prepare to process next statement
                 self._reset()
@@ -190,6 +203,17 @@ class StatementSplitter:
                 # Reset _seen_begin if we see a non-whitespace, non-comment
                 # token but not for BEGIN itself (which just set the flag)
                 self._seen_begin = False
+
+        # Flush the held statement and whatever remains. Any trailing tokens
+        # left in ``self.tokens`` after the last statement was completed are
+        # pure whitespace (the split was armed by ``consume_ws``); reattach
+        # them to that statement so the exact input is preserved on join,
+        # instead of dropping them as a dangling all-whitespace buffer.
+        if held_tokens is not None:
+            if self.tokens and all(t.is_whitespace for t in self.tokens):
+                held_tokens = held_tokens + self.tokens
+                self.tokens = []
+            yield sql.Statement(held_tokens)
 
         # Yield pending statement (if any)
         if self.tokens and not all(t.is_whitespace for t in self.tokens):

--- a/tests/test_split.py
+++ b/tests/test_split.py
@@ -152,6 +152,21 @@ def test_split_ignores_empty_newlines():
     assert stmts[1] == 'select bar;'
 
 
+@pytest.mark.parametrize('s', ['select 1;\n',
+                               'select 1;\r\n',
+                               'select 1;\n\n',
+                               'select 1;\n ',
+                               'select 1; \n',
+                               'select 1;\nselect 2;\n',
+                               ';\n'])
+def test_split_preserves_trailing_whitespace(s):
+    # parse() must be lossless: whitespace following the final ';' was being
+    # split into a dangling all-whitespace statement and dropped, so joining
+    # the parsed statements no longer reproduced the input whenever it ended
+    # in a newline after ';' (trailing spaces alone were already preserved).
+    assert ''.join(str(stmt) for stmt in sqlparse.parse(s)) == s
+
+
 def test_split_quotes_with_new_line():
     stmts = sqlparse.split('select "foo\nbar"')
     assert len(stmts) == 1


### PR DESCRIPTION
## What

`sqlparse.parse()` is meant to be lossless — joining the returned
statements should reproduce the input exactly. That held for trailing
spaces/tabs after the final `;`, but **not** for trailing whitespace
containing a newline:

```python
>>> import sqlparse
>>> s = "select 1;\n"
>>> "".join(str(x) for x in sqlparse.parse(s)) == s
False          # returns "select 1;" — the trailing "\n" is dropped
```

| input | `"".join(map(str, parse(input)))` before | after |
|---|---|---|
| `"select 1;"` | `"select 1;"` | `"select 1;"` |
| `"select 1; "` (space) | `"select 1; "` | `"select 1; "` |
| `"select 1;\n"` | `"select 1;"` ❌ | `"select 1;\n"` ✅ |
| `"select 1;\r\n"` | `"select 1;"` ❌ | `"select 1;\r\n"` ✅ |
| `"select 1;\n\n"` | `"select 1;"` ❌ | `"select 1;\n\n"` ✅ |
| `";\n"` | `";"` ❌ | `";\n"` ✅ |

Trailing spaces were preserved but trailing newlines were not, which is a
surprising inconsistency for a library whose core guarantee is that parsing
never mutates the SQL.

## Root cause

In `StatementSplitter.process()`, once a `;` sets `consume_ws = True`, a
following newline token is **deliberately** treated as "not whitespace" for
end-of-statement detection (see the existing comment: *"It will count
newline token as a non whitespace"*). This is what makes `"a;\nb;"` split
into two statements.

The side effect: that newline starts a fresh statement buffer. When the
whitespace is at the very **end** of the input there is no following
statement, so the buffer stays all-whitespace and is discarded by the final
`not all(t.is_whitespace ...)` guard — silently losing the exact input.

## Fix

Hold each completed statement back by one segment. A held statement is
emitted only once the next real (non-whitespace) token confirms a new
statement has actually begun, so **inter-statement newline placement is
byte-for-byte unchanged**:

```python
>>> [str(x) for x in sqlparse.parse("a;\nb;")]
['a;', '\nb;']          # identical to before
```

At end of stream, any leftover all-whitespace tokens are reattached to the
held statement instead of being dropped, making the trailing case lossless.

Unchanged behaviors (verified):
- Whitespace-only input (`"   "`, `"\n"`) still yields **zero** statements.
- Statement **count** is unchanged in every case.
- `sqlparse.split()` is unaffected — it `.strip()`s each statement anyway.

## Tests

Added a parametrized regression test
`tests/test_split.py::test_split_preserves_trailing_whitespace` covering
`\n`, `\r\n`, multiple/mixed trailing whitespace, the multi-statement case,
and a bare `;\n`.

Proof it guards the bug (stash the source fix, keep the test):

```
# without the fix
7 failed in 0.04s
# with the fix
7 passed in 0.01s
```

Also verified with a 200k-iteration round-trip fuzzer asserting
`str(parse(sql)) == sql` (excluding whitespace-only inputs): **31+ failures
before, 0 after**.

## Verification

- Full suite: **494 passed, 2 xfailed, 1 xpassed** (487 → 494; +7 new; no
  regressions).
- `ruff check` clean on both changed files.
- Diff: **+41 / −1** across `statement_splitter.py`, `tests/test_split.py`,
  and a `CHANGELOG` bullet.
