### PR TITLE
Recognize ROW_FORMAT as a keyword (issue773)

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -33,6 +33,9 @@ Bug Fixes
 
 * Fix statement splitting (issue845).
 * Fix a late-binding closure bug in `TokenList.token_not_matching`.
+* Recognize ``ROW_FORMAT`` as a keyword so that ``ALTER TABLE ... ROW_FORMAT=...``
+  no longer merges the table name and the option into a single identifier
+  (issue773).
 
 
 Release 0.5.5 (Dec 19, 2025)

--- a/sqlparse/keywords.py
+++ b/sqlparse/keywords.py
@@ -488,6 +488,7 @@ KEYWORDS = {
     'ROUTINE_SCHEMA': tokens.Keyword,
     'ROWS': tokens.Keyword,
     'ROW_COUNT': tokens.Keyword,
+    'ROW_FORMAT': tokens.Keyword,
     'RULE': tokens.Keyword,
 
     'SAVE_POINT': tokens.Keyword,

--- a/tests/test_regressions.py
+++ b/tests/test_regressions.py
@@ -454,6 +454,21 @@ def test_primary_key_issue740():
     assert p.tokens[0].ttype == T.Keyword
 
 
+def test_alter_table_row_format_issue773():
+    # ROW_FORMAT is a keyword (like ENGINE), so it must not be absorbed into
+    # the preceding table name as if it were an alias.
+    p = sqlparse.parse('ALTER TABLE mytable ROW_FORMAT=Dynamic')[0]
+    row_format = p.token_next_by(m=(T.Keyword, 'ROW_FORMAT'))[1]
+    assert row_format is not None
+    # The table name should be parsed as a standalone identifier.
+    assert isinstance(p.tokens[4], sql.Identifier)
+    assert p.tokens[4].get_real_name() == 'mytable'
+    assert p.tokens[4].get_alias() is None
+    # Sanity check: ENGINE (already a keyword) behaves the same way.
+    e = sqlparse.parse('ALTER TABLE mytable ENGINE=InnoDB')[0]
+    assert e.tokens[4].get_real_name() == 'mytable'
+
+
 @pytest.fixture
 def limit_recursion():
     curr_limit = sys.getrecursionlimit()


### PR DESCRIPTION
Fixes #773.

## Problem

`ALTER TABLE mytable ROW_FORMAT=Dynamic` parses the table name and the option together as a single identifier:

```python
>>> import sqlparse
>>> [str(t) for t in sqlparse.parse("ALTER TABLE mytable ROW_FORMAT=Dynamic")[0].tokens]
['ALTER', ' ', 'TABLE', ' ', 'mytable ROW_FORMAT', '=', 'Dynamic']
#                                ^^^^^^^^^^^^^^^^^^ table name absorbs the option
```

`ROW_FORMAT` was tokenized as a `Name`, so the identifier grouper treated it as an alias of `mytable` (`mytable ROW_FORMAT`).

## Fix

`ENGINE`, `AUTO_INCREMENT` and similar table options are already listed in `KEYWORDS`, which is why `ALTER TABLE mytable ENGINE=InnoDB` parses correctly (the table name is a standalone identifier). This adds `ROW_FORMAT` to `KEYWORDS` for consistent behavior:

```python
>>> [str(t) for t in sqlparse.parse("ALTER TABLE mytable ROW_FORMAT=Dynamic")[0].tokens]
['ALTER', ' ', 'TABLE', ' ', 'mytable', ' ', 'ROW_FORMAT', '=', 'Dynamic']
```

## Verification

- Added `test_alter_table_row_format_issue773` to `tests/test_regressions.py`; it fails on `main` (no `ROW_FORMAT` keyword) and passes with this change.
- Full test suite: `488 passed, 2 xfailed, 1 xpassed` (the `xpassed` is pre-existing and identical on `main`); no regressions.
- `ruff check sqlparse/` (the CI lint command) is clean.
- Added a `CHANGELOG` entry.

---

*Disclosure: this change was prepared with the assistance of an AI tool (Claude Code). I reproduced the issue, reviewed and verified the fix and test results, and take responsibility for the contribution and will respond to review feedback personally.*
