### PR TITLE
Fix BETWEEN with leading-dot decimals being mis-lexed (issue601)

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -33,6 +33,8 @@ Bug Fixes
 
 * Fix statement splitting (issue845).
 * Fix a late-binding closure bug in `TokenList.token_not_matching`.
+* Fix keyword before a leading-dot float being lexed as a name, e.g. in
+  ``BETWEEN .03 AND .06`` (issue601).
 
 
 Release 0.5.5 (Dec 19, 2025)

--- a/sqlparse/keywords.py
+++ b/sqlparse/keywords.py
@@ -49,7 +49,7 @@ SQL_REGEX = [
     # see issue #39
     # Spaces around period `schema . name` are valid identifier
     # TODO: Spaces before period not implemented
-    (r'[A-ZÀ-Ü]\w*(?=\s*\.)', tokens.Name),  # 'Name'.
+    (r'[A-ZÀ-Ü]\w*(?=\s*\.(?!\d))', tokens.Name),  # 'Name'.
     # FIXME(atronah): never match,
     # because `re.match` doesn't work with look-behind regexp feature
     (r'(?<=\.)[A-ZÀ-Ü]\w*', tokens.Name),  # .'Name'

--- a/tests/test_regressions.py
+++ b/tests/test_regressions.py
@@ -465,3 +465,16 @@ def limit_recursion():
 def test_max_recursion(limit_recursion):
     with pytest.raises(SQLParseError):
         sqlparse.parse('[' * 1000 + ']' * 1000)
+
+
+def test_between_leading_dot_float_issue601():
+    # a leading-dot float must not turn the preceding word into a Name
+    # by mistaking the decimal point for a qualified-name separator
+    p = sqlparse.parse('a between .03 and .06')[0]
+    tokens = [t for t in p.flatten() if not t.is_whitespace]
+    assert tokens[1].ttype is T.Keyword
+    assert tokens[1].value == 'between'
+    assert tokens[2].ttype is T.Number.Float
+    assert tokens[3].ttype is T.Keyword
+    assert tokens[3].value == 'and'
+    assert tokens[4].ttype is T.Number.Float


### PR DESCRIPTION
Fixes #601.

`sqlparse` mis-lexes `BETWEEN`/`AND` when the range bounds are decimals written without a leading zero:

```python
>>> import sqlparse
>>> sqlparse.parse("select * from t where l_discount between .03 and .06")[0].flatten()
# before: 'between' and 'and' come out as Token.Name (not Keyword),
#         corrupting the grouping into Identifiers like 'l_discount between'
```

The same query with `0.03` / `0.06` parses fine, which points at the leading dot.

**Cause:** the qualified-name rule in `SQL_REGEX` (`sqlparse/keywords.py`) is `[A-ZÀ-Ü]\w*(?=\s*\.)` — it matches a bareword followed by a `.`, intended for `schema.name`. But it also fires on `between` in `between .03`, mistaking the decimal point for a member-access period, so the keyword is swallowed as a name.

**Fix:** narrow the lookahead to `[A-ZÀ-Ü]\w*(?=\s*\.(?!\d))`, so the `.` only counts as member access when it is **not** followed by a digit. This is safe because SQL identifiers cannot start with a digit, so `name.<digit>` is never valid member access. Qualified names still work: `schema.table`, `db.schema.table`, `t.col`, `t.*`, `a.b.c.d` all verified unchanged. `.03`/`.06` were already matched by the float rule; they just weren't reached before because the name rule consumed the keyword.

Added a regression test in `tests/test_regressions.py` and a `CHANGELOG` entry. Full test suite passes (488 passed).
