### PR TITLE
fix: guard short parenthesis groups in StripWhitespaceFilter

### DIFF
--- a/sqlparse/filters/others.py
+++ b/sqlparse/filters/others.py
@@ -112,13 +112,15 @@ class StripWhitespaceFilter:
         return self._stripws_default(tlist)
 
     def _stripws_parenthesis(self, tlist):
-        while tlist.tokens[1].is_whitespace:
+        # Short groups (e.g. "(::)") lack open/body/close slots for inner ws pops.
+        while len(tlist.tokens) > 2 and tlist.tokens[1].is_whitespace:
             tlist.tokens.pop(1)
-        while tlist.tokens[-2].is_whitespace:
+        while len(tlist.tokens) > 2 and tlist.tokens[-2].is_whitespace:
             tlist.tokens.pop(-2)
-        if tlist.tokens[-2].is_group:
+        if len(tlist.tokens) > 2 and tlist.tokens[-2].is_group:
             # save to remove the last whitespace
-            while tlist.tokens[-2].tokens[-1].is_whitespace:
+            while (tlist.tokens[-2].tokens
+                   and tlist.tokens[-2].tokens[-1].is_whitespace):
                 tlist.tokens[-2].tokens.pop(-1)
         self._stripws_default(tlist)
 

--- a/tests/test_format.py
+++ b/tests/test_format.py
@@ -432,6 +432,9 @@ class TestFormatReindent:
         assert f("select f(\n\n\n1\n\n\n)") == 'select f(1)'
         assert f("select f(\n\n\n 1 \n\n\n)") == 'select f(1)'
         assert f("select f(\n\n\n  1  \n\n\n)") == 'select f(1)'
+        # Cast-like "(::)" is one Identifier inside Parenthesis; must not IndexError
+        assert f('(::)') == '(::)'
+        assert f('()') == '()'
 
     def test_where(self):
         f = lambda sql: sqlparse.format(sql, reindent=True)


### PR DESCRIPTION
sqlparse.filters.others.StripWhitespaceFilter._stripws_parenthesis hits IndexError when (::) with reindent=True. This PR fixes the regression with a focused test covering the case.
