### PR TITLE
Fix get_real_name for names with more than two dotted parts (#332)

### DIFF
--- a/sqlparse/sql.py
+++ b/sqlparse/sql.py
@@ -18,8 +18,11 @@ class NameAliasMixin:
 
     def get_real_name(self):
         """Returns the real name (object name) of this identifier."""
-        # a.b
-        dot_idx, _ = self.token_next_by(m=(T.Punctuation, '.'))
+        # a.b.c -> real name is the component after the *last* dot
+        dot_idx = None
+        for idx, tok in enumerate(self.tokens):
+            if tok.match(T.Punctuation, '.'):
+                dot_idx = idx
         return self._get_first_name(dot_idx, real_name=True)
 
     def get_alias(self):

--- a/tests/test_parse.py
+++ b/tests/test_parse.py
@@ -466,6 +466,24 @@ def test_get_real_name():
     assert 't' == stmts[0].tokens[2].get_alias()
 
 
+def test_get_real_name_multi_part_dotted():
+    # issue 332: for a fully-qualified name the real name is the component
+    # after the *last* dot, not an intermediate one.
+    ident = sqlparse.parse("db.schema.tbl.col")[0].tokens[0]
+    assert 'col' == ident.get_real_name()
+    assert 'col' == ident.get_name()
+    # the parent object still anchors on the first dot
+    assert 'db' == ident.get_parent_name()
+
+    aliased = sqlparse.parse("x.y.z AS w")[0].tokens[0]
+    assert 'z' == aliased.get_real_name()
+    assert 'w' == aliased.get_alias()
+
+    # two-part names and function calls stay correct
+    assert 'b' == sqlparse.parse("a.b")[0].tokens[0].get_real_name()
+    assert 'func' == sqlparse.parse("mydb.sch.func(1)")[0].tokens[0].get_real_name()
+
+
 def test_from_subquery():
     # issue 446
     s = 'from(select 1)'


### PR DESCRIPTION
Fixes #332.

### The bug

`get_real_name()` returns the wrong component for a fully-qualified name with more than two dotted parts:

```python
import sqlparse
ident = sqlparse.parse("db.schema.tbl.col")[0].tokens[0]
ident.get_real_name()   # 'schema'  — should be 'col'
ident.get_name()        # 'schema'  — should be 'col' (get_name falls back to real name)
```

More cases on current `master`: `a.b.c` → `'b'` (should be `'c'`), `x.y.z AS w` → real name `'y'` (should be `'z'`), `mydb.sch.func(1)` → `'sch'` (should be `'func'`). Two-part names like `a.b` → `'b'` are correct and stay correct.

This is issue #332 (open since 2017): the "object name" of `db.schema.tbl.col` is the last component, but the current result is an intermediate one that is neither the object nor its parent.

### Root cause

`NameAliasMixin.get_real_name` (`sqlparse/sql.py`) anchors on the **first** dot:

```python
dot_idx, _ = self.token_next_by(m=(T.Punctuation, '.'))   # first dot
return self._get_first_name(dot_idx, real_name=True)      # first name from there
```

`token_next_by` returns the first dot, so `_get_first_name` returns the component right after it — the second part. For a 2-part name the first dot is also the last, so it happened to be correct; for 3+ parts it stops too early.

`get_parent_name` documents the opposite intent — *"A parent object is identified by the first occurring dot"* — so the first-dot logic belongs there, not in `get_real_name`. The docstring of `get_real_name` says "the real name (object name)", which is unambiguously the component after the **last** dot.

### The fix

Anchor `get_real_name` on the last dot instead of the first. `get_parent_name` is untouched, so parent name and real name now come from opposite ends of the dotted path, as intended.

### Verification

- The repro above now returns `col`; `a.b.c` → `c`, `x.y.z AS w` → real `z` / alias `w`, `mydb.sch.func(1)` → `func`, `db.sch."My Table"` → `My Table`, `a.b.*` → `*`. Two-part names and `get_parent_name` are unchanged.
- Added `test_get_real_name_multi_part_dotted`; it fails on `master` (`assert 'col' == 'schema'`) and passes with the fix.
- Full suite: `488 passed, 2 xfailed, 1 xpassed` (was 487 + the new test) — no existing test relied on the old behavior. `ruff check sqlparse/sql.py` clean.

---

This PR was authored by an AI coding agent (Claude Code) running on this account: the AI found the bug, ran the repro, wrote the test, and wrote this description. The human account holder reviews every change and is accountable for it. The verification above is real and re-runnable from the diff. If this isn't the kind of contribution you want, say so and I'll close it.
