### PR TITLE
Fix function grouping skipped for lowercase 'as' in CREATE TABLE AS SELECT

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -33,6 +33,8 @@ Bug Fixes
 
 * Fix statement splitting (issue845).
 * Fix a late-binding closure bug in `TokenList.token_not_matching`.
+* Fix function grouping being skipped in ``CREATE TABLE ... AS SELECT``
+  statements when the ``as`` keyword is lowercase.
 
 
 Release 0.5.5 (Dec 19, 2025)

--- a/sqlparse/engine/grouping.py
+++ b/sqlparse/engine/grouping.py
@@ -381,7 +381,7 @@ def group_functions(tlist):
             has_create = True
         if tmp_token.value.upper() == 'TABLE':
             has_table = True
-        if tmp_token.value == 'AS':
+        if tmp_token.value.upper() == 'AS':
             has_as = True
     if has_create and has_table and not has_as:
         return

--- a/tests/test_grouping.py
+++ b/tests/test_grouping.py
@@ -344,6 +344,14 @@ def test_grouping_alias_ctas():
     assert p.tokens[10].get_alias() == 'col1'
     assert isinstance(p.tokens[10].tokens[0], sql.Function)
 
+
+def test_grouping_alias_ctas_lowercase_as():
+    # 'as' is case-insensitive; a lowercase keyword in CREATE TABLE ... AS
+    # SELECT must not disable function grouping in the SELECT body.
+    p = sqlparse.parse('create table tbl1 as select coalesce(t1.col1, 0) as col1 from t1')[0]
+    assert p.tokens[10].get_alias() == 'col1'
+    assert isinstance(p.tokens[10].tokens[0], sql.Function)
+
 def test_grouping_subquery_no_parens():
     # Not totally sure if this is the right approach...
     # When a THEN clause contains a subquery w/o parenthesis around it *and*


### PR DESCRIPTION
- [x] ran the tests (`pytest`)
- [x] all style issues addressed (`ruff`)
- [x] your changes are covered by tests
- [x] your changes are documented, if needed

In `group_functions` (`sqlparse/engine/grouping.py`), the guard that suppresses function grouping for `CREATE TABLE name (...)` checks three tokens, but only two are case-insensitive:

```python
if tmp_token.value.upper() == 'CREATE':
    has_create = True
if tmp_token.value.upper() == 'TABLE':
    has_table = True
if tmp_token.value == 'AS':        # case-sensitive
    has_as = True
```

Since SQL keywords are case-insensitive, a lowercase `as` in a `CREATE TABLE ... AS SELECT` (CTAS) statement leaves `has_as` False, so the guard fires and grouping returns early, skipping **all** function grouping for the statement.

```python
import sqlparse
from sqlparse import sql

p = sqlparse.parse("CREATE TABLE foo as SELECT count(x) FROM bar")[0]
# count(x) is left as a bare Name + Parenthesis instead of a sql.Function
```

With uppercase `AS` the same statement groups `count(x)` as a `Function`; only the keyword casing changes the parse tree. The existing `test_grouping_alias_ctas` covers the uppercase form.

The fix compares `as` case-insensitively like its sibling checks, and I added a lowercase regression test. The original guard behavior is preserved: `create table foo (a int, b int)` (no `AS`) still does not group `foo (...)` as a function in either case.
