### PR TITLE
fix(cli): point at --help when arguments are invalid

### DIFF
--- a/sqlparse/cli.py
+++ b/sqlparse/cli.py
@@ -27,10 +27,18 @@ from sqlparse.exceptions import SQLParseError
 
 # TODO: Add CLI Tests
 # TODO: Simplify formatter by using argparse `type` arguments
+class _ArgumentParser(argparse.ArgumentParser):
+    """ArgumentParser that points at --help when arguments are invalid."""
+
+    def error(self, message):
+        self.exit(2, f'{self.format_usage()}{self.prog}: error: {message}\n'
+                     f"Try '{self.prog} --help' for more information.\n")
+
+
 def create_parser():
     _CASE_CHOICES = ['upper', 'lower', 'capitalize']
 
-    parser = argparse.ArgumentParser(
+    parser = _ArgumentParser(
         prog='sqlformat',
         description='Format FILE according to OPTIONS. Use "-" as FILE '
                     'to read from stdin.',

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -204,3 +204,12 @@ def test_cli_error_handling_continues(tmpdir, capsys):
     assert "select * from baz" in file3.read()
     _, err = capsys.readouterr()
     assert "Failed to read" in err
+
+
+def test_cli_argument_error_mentions_help(capsys):
+    """Argument errors should point the user at --help."""
+    with pytest.raises(SystemExit) as exinfo:
+        sqlparse.cli.main([])
+    assert exinfo.value.code == 2
+    _, err = capsys.readouterr()
+    assert "Try 'sqlformat --help' for more information." in err


### PR DESCRIPTION
Closes #840

`sqlformat` with no arguments printed only the usage line and the error, with no hint that `--help` exists. A small `ArgumentParser` subclass overrides `error()` so every argument error is followed by `Try 'sqlformat --help' for more information.` Exit code stays 2.

Before submitting your pull request please have a look at the
following checklist:

- [x] ran the tests (`pytest`)
- [x] all style issues addressed (`ruff`)
- [x] your changes are covered by tests
- [x] your changes are documented, if needed
