### PR TITLE
perf: make ReindentFilter._get_offset linear in tokens instead of quadratic

### DIFF
--- a/sqlparse/filters/reindent.py
+++ b/sqlparse/filters/reindent.py
@@ -5,9 +5,46 @@
 # This module is part of python-sqlparse and is released under
 # the BSD License: https://opensource.org/licenses/BSD-3-Clause
 
+import re
+
 from sqlparse import sql
 from sqlparse import tokens as T
 from sqlparse.utils import indent, offset
+
+# The line boundaries str.splitlines() recognizes. Used only to tell whether a
+# token value can possibly affect the line count, never to split.
+HAS_LINE_BREAK = re.compile('[\n\r\v\f\x1c\x1d\x1e\x85\u2028\u2029]')
+
+
+class _Unreachable(Exception):
+    """*token* is not reachable from *group* by walking parents."""
+
+
+def _tokens_before(group, token):
+    """Yields the tokens of *group* that precede *token*, closest one first.
+
+    Groups are yielded whole rather than descended into, so ``str()`` on the
+    result still spells the preceding text but does not visit a leaf that the
+    caller may not need to look at.
+    """
+    # Record where *token* sits inside each of its ancestors, up to *group*.
+    ancestry = []
+    node = token
+    while node is not group:
+        parent = node.parent
+        try:
+            ancestry.append((parent.tokens, parent.tokens.index(node)))
+        except (AttributeError, ValueError):
+            # *token* is not reachable from *group* -- StripCommentsFilter, for
+            # one, splices in a replacement token whose parent is unset. The
+            # backwards walk cannot answer this, so say so and let the caller
+            # fall back to flattening the statement.
+            raise _Unreachable from None
+        node = parent
+
+    for siblings, tidx in ancestry:
+        for idx in range(tidx - 1, -1, -1):
+            yield siblings[idx]
 
 
 class ReindentFilter:
@@ -41,9 +78,51 @@ class ReindentFilter:
     def leading_ws(self):
         return self.offset + self.indent * self.width
 
+    def _preceding_line(self, token):
+        """Returns the last line of the text preceding *token*."""
+        if (type(self)._flatten_up_to_token is not _ORIG_FLATTEN_UP_TO_TOKEN
+                or '_flatten_up_to_token' in vars(self)):
+            # _flatten_up_to_token has been replaced -- by a subclass, on this
+            # class, or on this instance. Honour the replacement rather than the
+            # equivalent-but-faster walk below.
+            raw = ''.join(map(str, self._flatten_up_to_token(token)))
+            return (raw or '\n').splitlines()[-1]
+
+        if token.is_group:
+            token = next(token.flatten())
+
+        # Only the final line of the preceding text is ever used, so walk
+        # backwards from *token* and stop once the text collected is guaranteed
+        # to contain that whole line. Re-flattening the entire statement on
+        # every call is what made reindenting quadratic in the token count.
+        #
+        # Two line boundaries are needed rather than one, because splitlines()
+        # ignores a *trailing* boundary: "a\nb\n" ends on the line "b", so a
+        # token ending in a break does not start a fresh line. Stopping after
+        # the third token that holds a boundary guarantees two boundaries even
+        # in the worst case, where a "\r\n" is split across a token edge and so
+        # counts only once.
+        chunks = []
+        breaks = 0
+        try:
+            for t in _tokens_before(self._curr_stmt, token):
+                value = str(t)
+                chunks.append(value)
+                if HAS_LINE_BREAK.search(value):
+                    breaks += 1
+                    if breaks == 3:
+                        break
+        except _Unreachable:
+            # A token spliced in without a parent (StripCommentsFilter does
+            # this) cannot be located by walking parents. Flatten instead.
+            raw = ''.join(map(str, self._flatten_up_to_token(token)))
+            return (raw or '\n').splitlines()[-1]
+        chunks.reverse()
+
+        return (''.join(chunks) or '\n').splitlines()[-1]
+
     def _get_offset(self, token):
-        raw = ''.join(map(str, self._flatten_up_to_token(token)))
-        line = (raw or '\n').splitlines()[-1]
+        line = self._preceding_line(token)
         # Now take current offset into account and return relative offset.
         return len(line) - len(self.char * self.leading_ws)
 
@@ -246,3 +325,8 @@ class ReindentFilter:
 
         self._last_stmt = stmt
         return stmt
+
+
+# The shipped _flatten_up_to_token, captured so that _preceding_line can tell
+# whether it is still in place and only then take its faster equivalent path.
+_ORIG_FLATTEN_UP_TO_TOKEN = ReindentFilter._flatten_up_to_token


### PR DESCRIPTION
`ReindentFilter._get_offset` builds the text preceding a token by flattening the entire statement from the start, then keeps only the last line of it. It is called once per token that needs an offset, so reindenting is quadratic in the token count.

This walks backwards from the token instead, collecting only as much preceding text as is guaranteed to contain that final line. Groups are yielded whole rather than descended into, so `str()` on the result still spells the same text.

## Numbers

`time.process_time`, alternating base and patched subprocesses, min of 3, on nested function calls (`SELECT COALESCE(a,b,0) x n FROM t`):

| n   | master     | this branch | speedup | master growth | branch growth |
|----:|-----------:|------------:|--------:|--------------:|--------------:|
| 200 |  134.19 ms |    45.32 ms |   2.96x |         x3.00 |         x2.03 |
| 400 |  462.69 ms |    95.31 ms |   4.85x |         x3.45 |         x2.10 |
| 800 | 1669.31 ms |   217.01 ms |   7.69x |         x3.61 |         x2.28 |

The growth columns are the substance: `master` grows about 3.6x per doubling while this grows about 2x, so the quadratic term is gone and the speedup keeps increasing with statement size. A 400-row `INSERT ... VALUES` measures about 2.7x.

Not every statement benefits. Statements whose tokens mostly do not need an offset, such as a long flat `WHERE ... AND` chain, a large `IN` list, chained `UNION`s, or a wide flat `SELECT` column list, measure 0.92x to 1.08x, which is unchanged within noise. The win is specifically for nested and grouped constructs, since those are what call `_get_offset`.

## The trade-off, measured

Cost is now proportional to the length of the preceding line multiplied by the nesting depth, because a deeply nested group re-walks the same long preceding line once per level. So there is a shape that regresses.

A 200 KB literal followed by 30 flat grouped expressions is actually 1.27x faster. Nesting those same expressions 40 deep after a 200 KB literal measures 0.57x, roughly 2x slower than master. That is the honest worst case, and I would rather state it than have it found later.

## Behaviour

Three details here are load-bearing and each took a correction to get right.

`str.splitlines()` ignores a trailing boundary, so `"a\nb\n"` ends on the line `"b"`, and a token ending in a break does not start a fresh line. The walk therefore stops after the third token containing a boundary rather than the second, which guarantees the two boundaries needed even when a `\r\n` is split across a token edge and counts only once. Trimming each token to its own last line looks like a further win but is wrong for exactly this reason: it changed 219 of 20,435 differential cases when I tried it.

A token spliced into the tree without a parent cannot be located by walking parents. `StripCommentsFilter` does exactly that, so the walk signals the condition and falls back to flattening. Treating it as "nothing precedes this token" instead mis-indented a `CASE` containing a stripped comment:

```python
sqlparse.format('select case/*\nc\n*/when a=1 then 2 else 3 end from t',
                reindent=True, strip_comments=True)

master:   'select case\n           when a=1 then 2\n           else 3\n       end\nfrom t'
unfixed:  'select case\n      when a=1 then 2\n      else 3\n       end\nfrom t'
```

`_flatten_up_to_token` is effectively part of the surface, so if it has been replaced by a subclass, on the class, or on the instance, the original path is used instead of this walk. All three are verified to still see the override called, with byte-identical output.

Differential testing against `master`: 20,435 comparisons, being 4,087 SQL statements crossed with 5 formatting configs, 0 mismatches. The corpus covers every line boundary `splitlines()` recognises, boundaries inside string literals and comments, leading and trailing boundaries, runs of three or more, `\r\n` split across token edges, deep paren nesting, 200-column selects, and 4,000 randomly assembled fragments.

## Checks

`pytest` gives 494 passed, 2 xfailed, 1 xpassed, exit code 0, matching `master` exactly. `ruff check sqlparse/` is clean.

One small unrelated cleanup in this diff: the `HAS_LINE_BREAK` character class uses `\u2028` and `\u2029` escapes rather than the literal separator characters, since literal U+2028 and U+2029 in source are invisible and easy to mangle.
