### PR TITLE
Keep trailing block comments with the preceding statement

### DIFF
--- a/sqlparse/engine/statement_splitter.py
+++ b/sqlparse/engine/statement_splitter.py
@@ -150,14 +150,13 @@ class StatementSplitter:
 
     def process(self, stream):
         """Process the stream"""
-        EOS_TTYPE = T.Whitespace, T.Comment.Single
+        EOS_TTYPE = T.Whitespace, T.Comment.Single, T.Comment.Multiline
 
         # Run over all stream tokens
         for ttype, value in stream:
             # Yield token if we finished a statement and there's no whitespaces
             # It will count newline token as a non whitespace. In this context
             # whitespace ignores newlines.
-            # why don't multi line comments also count?
             if self.consume_ws and ttype not in EOS_TTYPE:
                 yield sql.Statement(self.tokens)
 

--- a/tests/test_split_trailing_comments.py
+++ b/tests/test_split_trailing_comments.py
@@ -1,0 +1,18 @@
+import sqlparse
+
+
+def test_split_keeps_trailing_block_comment_with_statement():
+    sql = "SELECT 1; /* trailing */\nSELECT 2;"
+
+    assert sqlparse.split(sql) == [
+        "SELECT 1; /* trailing */",
+        "SELECT 2;",
+    ]
+
+
+def test_split_trailing_comments_are_consistent():
+    block = "SELECT 1; /* trailing */\nSELECT 2;"
+    line = "SELECT 1; -- trailing\nSELECT 2;"
+
+    assert sqlparse.split(block)[0] == "SELECT 1; /* trailing */"
+    assert sqlparse.split(line)[0] == "SELECT 1; -- trailing"


### PR DESCRIPTION
## Summary

`StatementSplitter` already treats whitespace and single-line comments after a statement terminator as trailing content for that statement, but multiline comments were handled differently. A block comment immediately after a semicolon was therefore attached to the following SQL statement instead of the statement it followed.

This change adds `T.Comment.Multiline` to the end-of-statement trailing token types so line and block comments behave consistently.

Example:

```python
sqlparse.split("SELECT 1; /* trailing */\nSELECT 2;")
```

Before, the block comment became part of the second statement. With this change the result is:

```python
["SELECT 1; /* trailing */", "SELECT 2;"]
```

Regression tests cover the block-comment case and consistency with existing single-line comment behavior.

## Validation

I could not run the project test suite in this execution environment because a local checkout/dependency environment was unavailable. The branch is based directly on current upstream `master`, and the diff is limited to the splitter token classification plus focused regression tests.