### PR TITLE
Don't match the time zone literal as part of the TZCast keyword

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,7 +1,12 @@
 Development Version
 -------------------
 
-Nothing yet.
+Bug Fixes
+
+* The time zone literal is no longer matched as part of the `AT TIME ZONE`
+  keyword. It was recased along with the keyword, so
+  `format("SELECT ts AT TIME ZONE 'Asia/Tokyo'", keyword_case='upper')`
+  returned `'ASIA/TOKYO'`, and a doubled quote in the literal split the token.
 
 
 Release 0.6.0 (Aug 13, 2026)

--- a/sqlparse/keywords.py
+++ b/sqlparse/keywords.py
@@ -190,7 +190,7 @@ SQL_REGEX = [
     (r'(LATERAL\s+VIEW\s+)'
      r'(EXPLODE|INLINE|PARSE_URL_TUPLE|POSEXPLODE|STACK)\b',
      tokens.Keyword),
-    (r"(AT|WITH')\s+TIME\s+ZONE\s+'[^']+'", tokens.Keyword.TZCast),
+    (r"AT\s+TIME\s+ZONE\b", tokens.Keyword.TZCast),
     (r'(NOT\s+)?(LIKE|ILIKE|RLIKE)\b', tokens.Operator.Comparison),
     (r'(NOT\s+)?(REGEXP)(\s+(BINARY))?\b', tokens.Operator.Comparison),
     # Check for keywords, also returns tokens.Name if regex matches

--- a/tests/test_format.py
+++ b/tests/test_format.py
@@ -14,6 +14,22 @@ class TestFormat:
         res = sqlparse.format(sql.upper(), keyword_case='lower')
         assert res == 'select * from BAR; -- SELECT FOO\n'
 
+    def test_keywordcase_leaves_tz_literal_alone(self):
+        # The TZCast rule matches the time zone literal as part of the keyword
+        # token, so recasing the token used to rewrite the literal too. 'UTC' is
+        # the only zone the existing tests use, and it survives either case.
+        sql = "SELECT ts AT TIME ZONE 'Asia/Tokyo'"
+        assert sqlparse.format(sql, keyword_case='upper') == sql
+        assert sqlparse.format(sql, keyword_case='lower') == \
+            "select ts at time zone 'Asia/Tokyo'"
+        assert sqlparse.format(sql, keyword_case='capitalize') == \
+            "Select ts At time zone 'Asia/Tokyo'"
+
+        sql = "SELECT ts AT TIME ZONE 'America/New_York'"
+        assert sqlparse.format(sql, keyword_case='upper') == sql
+        assert sqlparse.format(sql, keyword_case='lower') == \
+            "select ts at time zone 'America/New_York'"
+
     def test_keywordcase_invalid_option(self):
         sql = 'select * from bar; -- select foo\n'
         with pytest.raises(SQLParseError):

--- a/tests/test_tokenize.py
+++ b/tests/test_tokenize.py
@@ -234,11 +234,24 @@ def test_near_like_and_ilike_parsed_appropriately(s):
 
 @pytest.mark.parametrize('s', (
     'AT TIME ZONE \'UTC\'',
+    'AT TIME ZONE \'Asia/Tokyo\'',
+    'AT TIME ZONE \'a\'\'b\'',
 ))
 def test_parse_tzcast(s):
+    # The keyword and the time zone literal are separate tokens: the literal is
+    # data, so it has to stay a String for the filters to leave it alone.
     p = sqlparse.parse(s)[0]
-    assert len(p.tokens) == 1
     assert p.tokens[0].ttype == T.Keyword.TZCast
+    assert p.tokens[0].value == 'AT TIME ZONE'
+    assert p.tokens[-1].ttype == T.String.Single
+    assert str(p) == s
+
+
+def test_parse_tzcast_groups_with_its_operand():
+    p = sqlparse.parse("SELECT ts AT TIME ZONE 'Asia/Tokyo'")[0]
+    identifier = p.tokens[-1]
+    assert isinstance(identifier, sql.Identifier)
+    assert str(identifier) == "ts AT TIME ZONE 'Asia/Tokyo'"
 
 
 def test_cli_commands():


### PR DESCRIPTION
`keyword_case` rewrites the contents of a time zone literal:

```python
>>> sqlparse.format("SELECT ts AT TIME ZONE 'Asia/Tokyo'", keyword_case='upper')
"SELECT ts AT TIME ZONE 'ASIA/TOKYO'"
```

The cause is in the TZCast rule, which matches the literal as part of the keyword:

```python
(r"(AT|WITH')\s+TIME\s+ZONE\s+'[^']+'", tokens.Keyword.TZCast),
```

`"AT TIME ZONE 'Asia/Tokyo'"` therefore arrives at `KeywordCaseFilter` as a single `Token.Keyword` and is recased whole, changing data the caller only asked to have reformatted.

Two more things follow from the same pattern:

* `'[^']+'` cannot express a doubled quote, so `AT TIME ZONE 'a''b'` is split into a TZCast holding `"AT TIME ZONE 'a'"` and a stray `String` token `"'b'"`.
* The `WITH'` alternative matches an apostrophe directly after `WITH`, which is not valid SQL anywhere, so that branch never fires. `TIMESTAMP WITH TIME ZONE` is tokenized as separate keywords and is unaffected either way.

### The change

Match only the keyword and leave the literal to the string rule, which already handles doubled quotes:

```python
(r"AT\s+TIME\s+ZONE\b", tokens.Keyword.TZCast),
```

Nothing downstream needed adjusting. `group_tzcasts` already accepts a following `String.Single` in `valid_next`, so the grouping layer was written expecting this token stream: `ts AT TIME ZONE 'Asia/Tokyo'` still groups into a single `Identifier`, with aliases and nested calls intact.

I took the narrower route first — teaching `KeywordCaseFilter` to skip the quoted part — and discarded it. It works around a token the filter should never receive and leaves the other two problems standing.

### Verification

The existing coverage for this rule is `'UTC'`, which reads the same in either case and holds no quote, so it passes whether or not the literal is rewritten. The new cases use `'Asia/Tokyo'` and `'a''b'`.

* `510 passed, 2 xfailed, 1 xpassed`
* Restoring the old regex fails 5 of the new assertions
* 984 statements from sqlglot's fixture corpus: no lossy round trips, and no literal altered by `keyword_case` in either direction (before the change, one was)
* `TIMESTAMP WITH TIME ZONE` and `TIMESTAMP WITHOUT TIME ZONE` confirmed to tokenize exactly as before
* `bench_lexer_delimiters`, `bench_grouping` and `bench_group_comments` all still report linear
* `ruff check sqlparse/` reports nothing new

One thing worth a maintainer's eye: `test_parse_tzcast` asserted `len(p.tokens) == 1` for a bare `AT TIME ZONE 'UTC'`. That encodes the old tokenization rather than a behaviour to preserve, and the bare form is not a valid statement on its own, so I replaced it with assertions on the token types and the round trip, plus a new test that grouping still yields one `Identifier` when there is an operand. Happy to restore it in some other form if you would rather keep it.
