### PR TITLE
Fix comment marker swallowed by preceding operator run

### DIFF
--- a/sqlparse/keywords.py
+++ b/sqlparse/keywords.py
@@ -200,7 +200,11 @@ SQL_REGEX = [
     # JSON operators
     (r'(\->>?|#>>?|@>|<@|\?\|?|\?&|\-|#\-)', tokens.Operator),
     (r'[<>=~!]+', tokens.Operator.Comparison),
-    (r'[+/@#%^&|^-]+', tokens.Operator),
+    # Negative lookahead keeps a `--` (or `# `) comment marker from being
+    # swallowed into a preceding operator run, e.g. `||--comment` must
+    # tokenize as `||` followed by a comment, not a single operator.
+    # See issue #722.
+    (r'(?:(?!--|# )[+/@#%^&|^-])+', tokens.Operator),
 ]
 
 KEYWORDS = {

--- a/tests/test_format.py
+++ b/tests/test_format.py
@@ -68,6 +68,12 @@ class TestFormat:
         res = ''
         assert res == sqlparse.format(sql, strip_comments=True)
 
+    def test_strip_comments_single_no_space_before_operator(self):
+        # see issue722
+        sql = 'foo || bar ||--comment\nbaz'
+        res = sqlparse.format(sql, strip_comments=True)
+        assert res == 'foo || bar ||\nbaz'
+
     def test_strip_comments_invalid_option(self):
         sql = 'select-- foo\nfrom -- bar\nwhere'
         with pytest.raises(SQLParseError):

--- a/tests/test_split.py
+++ b/tests/test_split.py
@@ -90,6 +90,19 @@ def test_split_comment_end_of_line():
     assert str(stmts[0]) == 'select * from foo; -- foo\n'
 
 
+def test_split_comment_directly_after_operator():
+    # see issue722: a `--` comment marker glued directly onto a preceding
+    # operator run (e.g. `||--`) must still be recognized as a comment, not
+    # merged into the operator token. The `;` right after `--` is part of
+    # the comment text (not a statement terminator), so this is genuinely
+    # a single statement; previously the bug caused it to be split in two.
+    sql = ('myval := oneval || otherval ||--;\n'
+           'continuedvals;\n')
+    stmts = sqlparse.split(sql)
+    assert len(stmts) == 1
+    assert stmts[0] == 'myval := oneval || otherval ||--;\ncontinuedvals;'
+
+
 def test_split_casewhen():
     sql = ("SELECT case when val = 1 then 2 else null end as foo;\n"
            "comment on table actor is 'The actor table.';")


### PR DESCRIPTION
## Bug

Fixes #722.

`sqlparse`'s operator regex (`[+/@#%^&|^-]+` in `sqlparse/keywords.py`) is
greedy and includes `-` in its character class. When a `--` (or `# `)
single-line comment marker immediately follows an operator with no
intervening whitespace, e.g. `||--comment`, the operator regex consumes the
whole `||--` run as a single `Operator` token before the comment regex ever
gets a chance to match. The comment is then invisible to the tokenizer.

Repro:
```python
import sqlparse
sql = "myval := oneval || otherval ||--;\ncontinuedvals;\n"
print(sqlparse.format(sql, strip_comments=True))
# strip_comments leaves the "--;" comment in place instead of stripping it
```

This can also make `sqlparse.split()` misjudge statement boundaries: a `;`
that lives inside an un-recognized "comment" gets treated as a real
statement terminator only in other contexts, but more directly, comment
content that should have been dropped is not.

## Fix

Add a negative lookahead to the operator regex so it stops consuming
characters right before a `--` or `# ` comment marker, letting the earlier
comment regex handle it as intended.

## Test plan

Added regression tests:
- `tests/test_format.py::TestFormat::test_strip_comments_single_no_space_before_operator`
- `tests/test_split.py::test_split_comment_directly_after_operator`

Both fail on `master` and pass with the fix. Ran the full test suite
locally:

```
python -m pytest tests/
508 passed, 2 xfailed, 1 xpassed
```

Also ran `ruff check sqlparse/keywords.py` — clean (pre-existing lint
findings elsewhere in the repo are unrelated to this change).